### PR TITLE
Remove globals, etc.

### DIFF
--- a/examples/preciseWithMovingPlayer.lua
+++ b/examples/preciseWithMovingPlayer.lua
@@ -1,5 +1,8 @@
 --[[ Precise Shadowcasting ]]--
-ROT=require 'rotLove/rotLove'
+
+setmetatable(_G, { __newindex = function (k, v) error('global ' .. v, 2) end })
+local ROT=require 'src/rot'
+setmetatable(_G, nil)
 
 function calbak(x, y, val)
     map[x..','..y]=val

--- a/src/action.lua
+++ b/src/action.lua
@@ -1,6 +1,7 @@
 --- Action based turn scheduler.
 -- @module ROT.Scheduler.Action
-local Action= ROT.Scheduler:extends("Action")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Action= ROT.Scheduler:extend("Action")
 function Action:init()
 	Action.super.init(self)
 	self._defaultDuration=1

--- a/src/arena.lua
+++ b/src/arena.lua
@@ -1,7 +1,8 @@
 --- The Arena map generator.
 -- Generates an arena style map. All cells except for the extreme borders are floors. The borders are walls.
 -- @module ROT.Map.Arena
-local Arena = ROT.Map:extends("Arena")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Arena = ROT.Map:extend("Arena")
 --- Constructor.
 -- Called with ROT.Map.Arena:new(width, height)
 -- @tparam int width Width in cells of the map

--- a/src/astar.lua
+++ b/src/astar.lua
@@ -1,7 +1,8 @@
 --- A* Pathfinding.
 -- Simplified A* algorithm: all edges have a value of 1
 -- @module ROT.Path.AStar
-local AStar=ROT.Path:extends("AStar")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local AStar=ROT.Path:extend("AStar")
 --- Constructor.
 -- @tparam int toX x-position of destination cell
 -- @tparam int toY y-position of destination cell

--- a/src/bresenham.lua
+++ b/src/bresenham.lua
@@ -2,7 +2,8 @@
 -- See http://en.wikipedia.org/wiki/Bresenham's_line_algorithm.
 -- Included for sake of having options. Provides three functions for computing FOV
 -- @module ROT.FOV.Bresenham
-local Bresenham=ROT.FOV:extends("Bresenham")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Bresenham=ROT.FOV:extend("Bresenham")
 --- Constructor.
 -- Called with ROT.FOV.Bresenham:new()
 -- @tparam function lightPassesCallback A function with two parameters (x, y) that returns true if a map cell will allow light to pass through

--- a/src/brogue.lua
+++ b/src/brogue.lua
@@ -1,7 +1,8 @@
 --- The Brogue Map Generator.
 -- Based on the description of Brogues level generation at http://brogue.wikia.com/wiki/Level_Generation
 -- @module ROT.Map.Brogue
-local Brogue=ROT.Map.Dungeon:extends("Brogue")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Brogue=ROT.Map.Dungeon:extend("Brogue")
 
 --- Constructor.
 -- Called with ROT.Map.Brogue:new(). A note: Brogue's map is 79x29. Consider using those dimensions for Display if you're looking to build a brogue-like.

--- a/src/brogueRoom.lua
+++ b/src/brogueRoom.lua
@@ -1,7 +1,8 @@
 --- BrogueRoom object.
 -- Used by ROT.Map.Brogue to create maps with 'cross rooms'
 -- @module ROT.Map.BrogueRoom
-local BrogueRoom = ROT.Map.Feature:extends("BrogueRoom")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local BrogueRoom = ROT.Map.Feature:extend("BrogueRoom")
 --- Constructor.
 -- creates a new BrogueRoom object with the assigned values
 -- @tparam table dims Represents dimensions and positions of the rooms two rectangles

--- a/src/cellular.lua
+++ b/src/cellular.lua
@@ -1,6 +1,7 @@
 --- Cellular Automaton Map Generator
 -- @module ROT.Map.Cellular
-local Cellular = ROT.Map:extends("Cellular")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Cellular = ROT.Map:extend("Cellular")
 --- Constructor.
 -- Called with ROT.Map.Cellular:new()
 -- @tparam int width Width in cells of the map

--- a/src/class.lua
+++ b/src/class.lua
@@ -1,0 +1,24 @@
+local USE_30LOG = true
+local PATH = (...):gsub('[^./\\]*$', '')
+
+if USE_30LOG then
+    local ok, class = pcall(require, PATH .. 'vendor.30log')
+    if ok then return class('BaseClass') end
+end
+
+-- built-in fallback
+
+local function new (proto, ...)
+    local instance = setmetatable({}, proto)
+    instance:init(...)
+    return instance
+end
+
+local function extend (super, name, t)
+    t = t or {}
+    t.__index, t.super = t, super
+    return setmetatable(t, { __call = new, __index = super })
+end
+
+return extend(nil, nil, { new = new, extend = extend, init = function()end })
+

--- a/src/color.lua
+++ b/src/color.lua
@@ -4,10 +4,9 @@
 -- table of the following schema:
 -- @module ROT.Color
 
-local Color_PATH=({...})[1]:gsub("[%.\\/]color$", "") .. '/'
-local class  =require (Color_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Color = ROT.Class:extend("Color")
 
-local Color=class("Color")
 function Color:init()
     self._rng = ROT.RNG.Twister:new()
     self._rng:randomseed()

--- a/src/corridor.lua
+++ b/src/corridor.lua
@@ -1,7 +1,8 @@
 --- Corridor object.
 -- Used by ROT.Map.Uniform and ROT.Map.Digger to create maps
 -- @module ROT.Map.Corridor
-local Corridor = ROT.Map.Feature:extends("Corridor")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Corridor = ROT.Map.Feature:extend("Corridor")
 --- Constructor.
 -- Called with ROT.Map.Corridor:new()
 -- @tparam int startX x-position of first floospace in corridor

--- a/src/dice.lua
+++ b/src/dice.lua
@@ -2,10 +2,8 @@
 -- Based off the RL-Dice library at https://github.com/timothymtorres/RL-Dice
 -- @module ROT.Dice
 
-local Dice_PATH =({...})[1]:gsub("[%.\\/]dice$", "") .. '/'
-local class  =require (Dice_PATH .. 'vendor/30log')
-
-local Dice=class("Dice", {minimum=1}) -- class default lowest possible roll is 1  (can set to nil to allow negative rolls)
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Dice = ROT.Class:extend("Dice", {minimum=1}) -- class default lowest possible roll is 1  (can set to nil to allow negative rolls)
 
 --- Constructor that creates a new dice instance
 -- @tparam ?int|string dice_notation Can be either a dice string, or int

--- a/src/digger.lua
+++ b/src/digger.lua
@@ -1,7 +1,8 @@
 --- The Digger Map Generator.
 -- See http://www.roguebasin.roguelikedevelopment.org/index.php?title=Dungeon-Building_Algorithm.
 -- @module ROT.Map.Digger
-local Digger=ROT.Map.Dungeon:extends("Digger")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Digger=ROT.Map.Dungeon:extend("Digger")
 --- Constructor.
 -- Called with ROT.Map.Digger:new()
 -- @tparam int width Width in cells of the map

--- a/src/dijkstra.lua
+++ b/src/dijkstra.lua
@@ -1,7 +1,8 @@
 --- Dijkstra Pathfinding.
 -- Simplified Dijkstra's algorithm: all edges have a value of 1
 -- @module ROT.Path.Dijkstra
-local Dijkstra=ROT.Path:extends("Dijkstra")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Dijkstra=ROT.Path:extend("Dijkstra")
 --- Constructor.
 -- @tparam int toX x-position of destination cell
 -- @tparam int toY y-position of destination cell

--- a/src/dijkstraMap.lua
+++ b/src/dijkstraMap.lua
@@ -1,10 +1,8 @@
 --- DijkstraMap Pathfinding.
 -- Based on the DijkstraMap Article on RogueBasin, http://roguebasin.roguelikedevelopment.org/index.php?title=The_Incredible_Power_of_Dijkstra_Maps
 -- @module ROT.DijkstraMap
-local DijkstraMap_PATH=({...})[1]:gsub("[%.\\/]dijkstraMap$", "") .. '/'
-local class  =require (DijkstraMap_PATH .. 'vendor/30log')
-
-local DijkstraMap=class("DijkstraMap")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local DijkstraMap = ROT.Class:extend("DijkstraMap")
 
 --- Constructor.
 -- @tparam int goalX x-position of cell that map will 'roll down' to

--- a/src/display.lua
+++ b/src/display.lua
@@ -1,10 +1,9 @@
 --- Visual Display.
 -- A Code Page 437 terminal emulator based on AsciiPanel.
 -- @module ROT.Display
-local Display_Path = ({...})[1]:gsub("[%.\\/]display$", "") .. '/'
-local class=require (Display_Path .. 'vendor/30log')
-
-local Display = class("Display")
+local Display_Path = (...):gsub('[^./\\]*$', ''):gsub('[./\\]', '/')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Display = ROT.Class:extend("Display")
 
 --- Constructor.
 -- The display constructor. Called when ROT.Display:new() is called.

--- a/src/dividedMaze.lua
+++ b/src/dividedMaze.lua
@@ -1,7 +1,8 @@
 --- The Divided Maze Map Generator.
 -- Recursively divided maze, http://en.wikipedia.org/wiki/Maze_generation_algorithm#Recursive_division_method
 -- @module ROT.Map.DividedMaze
-local DividedMaze = ROT.Map:extends("DividedMaze")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local DividedMaze = ROT.Map:extend("DividedMaze")
 --- Constructor.
 -- Called with ROT.Map.DividedMaze:new(width, height)
 -- @tparam int width Width in cells of the map

--- a/src/dungeon.lua
+++ b/src/dungeon.lua
@@ -1,7 +1,8 @@
 --- The Dungeon-style map Prototype.
 -- This class is extended by ROT.Map.Digger and ROT.Map.Uniform
 -- @module ROT.Map.Dungeon
-local Dungeon = ROT.Map:extends("Dungeon")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Dungeon = ROT.Map:extend("Dungeon")
 --- Constructor.
 -- Called with ROT.Map.Cellular:new()
 -- @tparam int width Width in cells of the map

--- a/src/ellerMaze.lua
+++ b/src/ellerMaze.lua
@@ -1,7 +1,8 @@
 --- The Eller Maze Map Generator.
 -- See http://homepages.cwi.nl/~tromp/maze.html for explanation
 -- @module ROT.Map.EllerMaze
-local EllerMaze = ROT.Map:extends("EllerMaze")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local EllerMaze = ROT.Map:extend("EllerMaze")
 
 --- Constructor.
 -- Called with ROT.Map.EllerMaze:new(width, height)

--- a/src/engine.lua
+++ b/src/engine.lua
@@ -1,7 +1,6 @@
-local Engine_PATH =({...})[1]:gsub("[%.\\/]engine$", "") .. '/'
-local class  =require (Engine_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Engine = ROT.Class:extend("Engine")
 
-local Engine = class("Engine")
 function Engine:init(scheduler)
 	self._scheduler=scheduler
 	self._lock     =1

--- a/src/eventQueue.lua
+++ b/src/eventQueue.lua
@@ -1,10 +1,7 @@
 --- Stores and retrieves events based on time.
 -- @module ROT.EventQueue
-
-local EventQueue_Path =({...})[1]:gsub("[%.\\/]eventQueue$", "") .. '/'
-local class  =require (EventQueue_Path .. 'vendor/30log')
-
-local EventQueue = class("EventQueue", {
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local EventQueue = ROT.Class:extend("EventQueue", {
     _time      =0,
     _events    ={},
     _eventTimes={}

--- a/src/feature.lua
+++ b/src/feature.lua
@@ -1,7 +1,6 @@
-local Feature_PATH =({...})[1]:gsub("[%.\\/]feature$", "") .. '/'
-local class  =require (Feature_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Feature = ROT.Class:extend("Feature")
 
-local Feature = class("Feature")
 function Feature:isValid() end
 function Feature:create() end
 function Feature:debug() end

--- a/src/fov.lua
+++ b/src/fov.lua
@@ -1,7 +1,6 @@
-local FOV_PATH =({...})[1]:gsub("[%.\\/]fov$", "") .. '/'
-local class  =require (FOV_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local FOV = ROT.Class:extend("FOV")
 
-local FOV=class{("FOV")
 function FOV:init(lightPassesCallback, options)
     self._lightPasses=lightPassesCallback
     self._options={topology=8}

--- a/src/iceyMaze.lua
+++ b/src/iceyMaze.lua
@@ -1,7 +1,8 @@
 --- The Icey Maze Map Generator.
 -- See http://www.roguebasin.roguelikedevelopment.org/index.php?title=Simple_maze for explanation
 -- @module ROT.Map.IceyMaze
-local IceyMaze = ROT.Map:extends("IceyMaze")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local IceyMaze = ROT.Map:extend("IceyMaze")
 --- Constructor.
 -- Called with ROT.Map.IceyMaze:new(width, height, regularity)
 -- @tparam int width Width in cells of the map

--- a/src/lcg.lua
+++ b/src/lcg.lua
@@ -1,6 +1,7 @@
 --- Linear Congruential Generator. A random number generator based on RandomLua
 -- @module ROT.RNG.LCG
-local LCG=ROT.RNG:extends("LCG")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local LCG=ROT.RNG:extend("LCG")
 
 --- Constructor.
 -- Called with ROT.RNG.LCG:new(r)

--- a/src/lighting.lua
+++ b/src/lighting.lua
@@ -1,10 +1,9 @@
 --- Lighting Calculator.
 -- based on a traditional FOV for multiple light sources and multiple passes.
 -- @module ROT.Lighting
-local Lighting_PATH=({...})[1]:gsub("[%.\\/]lighting$", "") .. '/'
-local class  =require (Lighting_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Lighting = ROT.Class:extend("Lighting")
 
-local Lighting=class("Lighting")
 --- Constructor.
 -- Called with ROT.Color:new()
 -- @tparam function reflectivityCallback Callback to retrieve cell reflectivity must return float(0..1)

--- a/src/line.lua
+++ b/src/line.lua
@@ -1,7 +1,6 @@
-local Line_PATH =({...})[1]:gsub("[%.\\/]line$", "") .. '/'
-local class  =require (Line_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Line = ROT.Class:extend("Line")
 
-local Line=class("Line")
 function Line:init(x1, y1, x2, y2)
     self.x1=x1
     self.y1=y1

--- a/src/map.lua
+++ b/src/map.lua
@@ -1,7 +1,6 @@
-local Map_PATH =({...})[1]:gsub("[%.\\/]map$", "") .. '/'
-local class  =require (Map_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Map = ROT.Class:extend("Map")
 
-local Map=class("Map")
 function Map:init(width, height)
 	self._width = width and width or ROT.DEFAULT_WIDTH
 	self._height= height and height or ROT.DEFAULT_HEIGHT

--- a/src/mwc.lua
+++ b/src/mwc.lua
@@ -1,6 +1,7 @@
 --- Multiply With Carry. A random number generator based on RandomLua
 -- @module ROT.RNG.MWC
-local MWC=ROT.RNG:extends("MWC")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local MWC=ROT.RNG:extend("MWC")
 --- Constructor.
 -- Called with ROT.RNG.MWC:new(r)
 -- @tparam[opt] string r Choose to populate the rng with values from numerical recipes or mvc as opposed to Ansi C. Accepted values 'nr', 'mvc'

--- a/src/newFuncs.lua
+++ b/src/newFuncs.lua
@@ -1,3 +1,23 @@
+-- asserts the type of 'theTable' is table
+local function isATable(theTable)
+    assert(type(theTable)=='table', "bad argument #1 to 'random' (table expected got "..type(theTable)..")")
+end
+
+-- returns string of length n consisting of only char c
+local function charNTimes(c, n)
+    assert(#c==1, 'character must be a string of length 1')
+    local s=''
+    for _=1,n and n or 2 do
+        s=s..c
+    end
+    return s
+end
+
+-- io.write(arg..'\n')
+local function write(str)
+    io.write(str..'\n')
+end
+
 -- New Table Functions
 -- returns random table element, nil if length is 0
 function table.random(theTable)
@@ -68,24 +88,10 @@ function table.indexOfTable(values, value)
     return 0
 end
 
--- asserts the type of 'theTable' is table
-function isATable(theTable)
-    assert(type(theTable)=='table', "bad argument #1 to 'random' (table expected got "..type(theTable)..")")
-end
-
 -- New String functions
 -- first letter capitalized
 function string:capitalize()
     return self:sub(1,1):upper() .. self:sub(2)
-end
--- returns string of length n consisting of only char c
-function charNTimes(c, n)
-    assert(#c==1, 'character must be a string of length 1')
-    local s=''
-    for _=1,n and n or 2 do
-        s=s..c
-    end
-    return s
 end
 -- left pad with c char, repeated n times
 function string:lpad(c, n)
@@ -140,7 +146,3 @@ function math.round(n, mult)
     return math.floor((n + mult/2)/mult) * mult
 end
 
--- io.write(arg..'\n')
-function write(str)
-    io.write(str..'\n')
-end

--- a/src/noise.lua
+++ b/src/noise.lua
@@ -1,7 +1,5 @@
-local Noise_PATH =({...})[1]:gsub("[%.\\/]noise$", "") .. '/'
-local class  =require (Noise_PATH .. 'vendor/30log')
-
-local Noise=class("Noise")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Noise = ROT.Class:extend("Noise")
 
 function Noise:get() end
 

--- a/src/path.lua
+++ b/src/path.lua
@@ -1,7 +1,6 @@
-local Path_PATH=({...})[1]:gsub("[%.\\/]path$", "") .. '/'
-local class  =require (Path_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Path = ROT.Class:extend("Path")
 
-local Path=class("Path")
 function Path:init(toX, toY, passableCallback, options)
     self._toX  =toX
     self._toY  =toY

--- a/src/point.lua
+++ b/src/point.lua
@@ -1,7 +1,6 @@
-local Point_PATH =({...})[1]:gsub("[%.\\/]point$", "") .. '/'
-local class  =require (Point_PATH .. 'vendor/30log')
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Point = ROT.Class:extend("Point")
 
-local Point=class("Point")
 function Point:init(x, y)
     self.x=x
     self.y=y

--- a/src/precise.lua
+++ b/src/precise.lua
@@ -2,7 +2,8 @@
 -- The Precise shadow casting algorithm developed by Ondřej Žára for rot.js.
 -- See http://roguebasin.roguelikedevelopment.org/index.php?title=Precise_Shadowcasting_in_JavaScript
 -- @module ROT.FOV.Precise
-local Precise=ROT.FOV:extends("Precise")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Precise=ROT.FOV:extend("Precise")
 --- Constructor.
 -- Called with ROT.FOV.Precise:new()
 -- @tparam function lightPassesCallback A function with two parameters (x, y) that returns true if a map cell will allow light to pass through
@@ -44,6 +45,20 @@ function Precise:compute(x, y, R, callback)
             if #SHADOWS==2 and SHADOWS[1][1]==0 and SHADOWS[2][1]==SHADOWS[2][2] then
                 break
             end
+        end
+    end
+end
+
+local function splice(t, i, rn, it) -- table, index, numberToRemove, insertTable
+    if rn>0 then
+        for _=1,rn do
+            table.remove(t, i)
+        end
+    end
+    if it and #it>0 then
+        for idx=i,i+#it-1 do
+            local el=table.remove(it, 1)
+            if el then table.insert(t, idx, el) end
         end
     end
 end
@@ -118,20 +133,6 @@ function Precise:_checkVisibility(A1, A2, blocks, SHADOWS)
 
     local arcLength=(A2[1]*A1[2] - A1[1]*A2[2]) / (A1[2]*A2[2])
     return visibleLength/arcLength
-end
-
-function splice(t, i, rn, it) -- table, index, numberToRemove, insertTable
-    if rn>0 then
-        for _=1,rn do
-            table.remove(t, i)
-        end
-    end
-    if it and #it>0 then
-        for idx=i,i+#it-1 do
-            local el=table.remove(it, 1)
-            if el then table.insert(t, idx, el) end
-        end
-    end
 end
 
 return Precise

--- a/src/recursive.lua
+++ b/src/recursive.lua
@@ -2,7 +2,8 @@
 -- The Recursive shadow casting algorithm developed by Ondřej Žára for rot.js.
 -- See http://roguebasin.roguelikedevelopment.org/index.php?title=Recursive_Shadowcasting_in_JavaScript
 -- @module ROT.FOV.Recursive
-local Recursive=ROT.FOV:extends("Recursive")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Recursive=ROT.FOV:extend("Recursive")
 --- Constructor.
 -- Called with ROT.FOV.Recursive:new()
 -- @tparam function lightPassesCallback A function with two parameters (x, y) that returns true if a map cell will allow light to pass through

--- a/src/rng.lua
+++ b/src/rng.lua
@@ -1,11 +1,8 @@
 --- The RNG Prototype.
 -- The base class that is extended by all rng classes
--- @module ROT.RNG
-
-local RNG_PATH =({...})[1]:gsub("[%.\\/]rng$", "") .. '/'
-local class  =require (RNG_PATH .. 'vendor/30log')
-
-local RNG=class("RNG")
+-- @module ROT.RNG.
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local RNG = ROT.Class:extend("RNG")
 
 function RNG:normalize(n) --keep numbers at (positive) 32 bits
     return n % 0x80000000

--- a/src/rogue.lua
+++ b/src/rogue.lua
@@ -2,7 +2,8 @@
 -- A map generator based on the original Rogue map gen algorithm
 -- See http://kuoi.com/~kamikaze/GameDesign/art07_rogue_dungeon.php
 -- @module ROT.Map.Rogue
-local Rogue=ROT.Map:extends("Rogue")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Rogue=ROT.Map:extend("Rogue")
 --- Constructor.
 -- @tparam int width Width in cells of the map
 -- @tparam int height Height in cells of the map
@@ -275,7 +276,7 @@ function Rogue:_getWallPosition(aRoom, aDirection)
     return {rx, ry}
 end
 
-function roomDebug(room)
+local function roomDebug(room)
     write(room.x
           ..','..room.y
           ..','..room.width

--- a/src/room.lua
+++ b/src/room.lua
@@ -1,7 +1,8 @@
 --- Room object.
 -- Used by ROT.Map.Uniform and ROT.Map.Digger to create maps
 -- @module ROT.Map.Room
-local Room = ROT.Map.Feature:extends("Room")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Room = ROT.Map.Feature:extend("Room")
 --- Constructor.
 -- creates a new room object with the assigned values
 -- @tparam int x1 Left wall

--- a/src/rot.lua
+++ b/src/rot.lua
@@ -1,7 +1,7 @@
-local ROTLOVE_PATH =({...})[1]:gsub("[%.\\/]rot$", "") .. '/'
-local class  =require (ROTLOVE_PATH .. 'vendor/30log')
+local ROTLOVE_PATH = (...):gsub('[^./\\]*$', '')
+local Class = require (ROTLOVE_PATH .. 'class')
 
-ROT=class("ROT", {
+local ROT = Class:extend('ROT', {
 	DEFAULT_WIDTH =80,
 	DEFAULT_HEIGHT=24,
 
@@ -23,7 +23,10 @@ ROT=class("ROT", {
 		       }
 		  }
 })
+package.loaded[...] = ROT
 require (ROTLOVE_PATH .. 'newFuncs')
+
+ROT.Class = Class
 
 --[[--------------------------------]]--
 -- All RNG 'classes' and functions derived from RandomLua

--- a/src/scheduler.lua
+++ b/src/scheduler.lua
@@ -1,10 +1,8 @@
 --- The Scheduler Prototype
 -- @module ROT.Scheduler
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Scheduler = ROT.Class:extend("Scheduler")
 
-local Scheduler_Path =({...})[1]:gsub("[%.\\/]scheduler$", "") .. '/'
-local class  =require (Scheduler_Path .. 'vendor/30log')
-
-local Scheduler = class("Scheduler")
 function Scheduler:init()
 	self._queue=ROT.EventQueue:new()
 	self._repeat ={}

--- a/src/simple.lua
+++ b/src/simple.lua
@@ -1,6 +1,7 @@
 --- The simple scheduler.
 -- @module ROT.Scheduler.Simple
-local Simple= ROT.Scheduler:extends("Simple")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Simple= ROT.Scheduler:extend("Simple")
 
 --- Add.
 -- Add an item to the schedule

--- a/src/simplex.lua
+++ b/src/simplex.lua
@@ -5,7 +5,8 @@
 -- With Optimisations by Peter Eastman (peastman@drizzle.stanford.edu).
 -- Better rank ordering method by Stefan Gustavson in 2012.
 -- @module ROT.Noise.Simplex
-local Simplex=ROT.Noise:extends("Simplex")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Simplex=ROT.Noise:extend("Simplex")
 --- Constructor.
 -- 2D simplex noise generator.
 -- @tparam int gradients The random values for the noise.

--- a/src/speed.lua
+++ b/src/speed.lua
@@ -1,6 +1,7 @@
 --- The Speed based scheduler
 -- @module ROT.Scheduler.Speed
-local Speed= ROT.Scheduler:extends("Speed")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Speed= ROT.Scheduler:extend("Speed")
 --- Add.
 -- Add an item to the schedule
 -- @tparam userdata item Any class/module/userdata with a :getSpeed() function. The value returned by getSpeed() should be a number.

--- a/src/stringGenerator.lua
+++ b/src/stringGenerator.lua
@@ -1,10 +1,8 @@
 --- Random String Generator.
 -- Learns from provided strings, and generates similar strings.
 -- @module ROT.StringGenerator
-local StringGen_Path =({...})[1]:gsub("[%.\\/]stringGenerator$", "") .. '/'
-local class  =require (StringGen_Path .. 'vendor/30log')
-
-local StringGenerator = class("StringGenerator")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local StringGenerator = ROT.Class:extend("StringGenerator")
 
 --- Constructor.
 -- Called with ROT.StringGenerator:new()

--- a/src/textDisplay.lua
+++ b/src/textDisplay.lua
@@ -1,9 +1,8 @@
 --- Visual Display.
 -- A UTF-8 based text display.
 -- @module ROT.TextDisplay
-local TextDisplay_Path = ({...})[1]:gsub("[%.\\/]textDisplay$", "") .. '/'
-local class=require (TextDisplay_Path .. 'vendor/30log')
-local TextDisplay=class("TextDisplay")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local TextDisplay = ROT.Class:extend("TextDisplay")
 
 --- Constructor.
 -- The display constructor. Called when ROT.TextDisplay:new() is called.

--- a/src/twister.lua
+++ b/src/twister.lua
@@ -1,6 +1,8 @@
 --- Mersenne Twister. A random number generator based on RandomLua
 -- @module ROT.RNG.Twister
-local Twister=ROT.RNG:extends("Twister")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Twister = ROT.RNG:extend("Twister")
+
 function Twister:init()
     self.mt={}
     self.index=0

--- a/src/uniform.lua
+++ b/src/uniform.lua
@@ -1,7 +1,8 @@
 --- The Uniform Map Generator.
 -- See http://www.roguebasin.roguelikedevelopment.org/index.php?title=Dungeon-Building_Algorithm.
 -- @module ROT.Map.Uniform
-local Uniform=ROT.Map.Dungeon:extends("Uniform")
+local ROT = require((...):gsub('[^./\\]*$', '') .. 'rot')
+local Uniform=ROT.Map.Dungeon:extend("Uniform")
 
 --- Constructor.
 -- Called with ROT.Map.Uniform:new()


### PR DESCRIPTION
- Removes all globals (main ROT module, and some hoisted functions).
- Introduces a base class, ROT.Class, so that all classes are declared in a uniform way.
- User can drop in a different class library by overwriting ROT.Class before requiring the main library. The new base class just needs to be given an `extend` function conforming to 30log's API.
- 30log is made optional; a minimal shim is provided as a fallback. The shim provides all 30log features currently used by rotLove and nothing else.

Also updated preciseWithMovingPlayer demo just for testing purposes (none of the demos tested the files in /src; they weren't actually working due to a few typos).