### PR TITLE
Switch to numeric-indexed colors.

### DIFF
--- a/examples/astar.lua
+++ b/examples/astar.lua
@@ -37,14 +37,14 @@ function doTheThing()
     start=os.clock()
     astar:compute(p3[1], p3[2], astarCallback)
 
-    f:write('S', tonumber(p1[1]), tonumber(p1[2]), nil, {r=0, g=0, b=255, a=255})
-    f:write('E', tonumber(p2[1]), tonumber(p2[2]), nil, {r=0, g=0, b=255, a=255})
-    f:write('E', tonumber(p3[1]), tonumber(p3[2]), nil, {r=0, g=0, b=255, a=255})
+    f:write('S', tonumber(p1[1]), tonumber(p1[2]), nil, { 0, 0, 255, 255 })
+    f:write('E', tonumber(p2[1]), tonumber(p2[2]), nil, { 0, 0, 255, 255 })
+    f:write('E', tonumber(p3[1]), tonumber(p3[2]), nil, { 0, 0, 255, 255 })
 
 end
 
 function astarCallback(x, y)
-    f:write('.', x, y, nil, {r=136, g=0, b=0, a=255})
+    f:write('.', x, y, nil, { 136, 0, 0, 255 })
 end
 
 function passableCallback(x, y) return data[x..','..y]==0 end

--- a/examples/bresenham.lua
+++ b/examples/bresenham.lua
@@ -3,7 +3,7 @@ ROT=require 'src.rot'
 
 function calbak(x, y, val)
     map[x..','..y]=val
-    f:write(val==1 and '#' or '.', x, y, {r=110, g=110, b=110, a=255}, {r=0, g=0, b=0, a=255})
+    f:write(val==1 and '#' or '.', x, y, { 110, 110, 110, 255 }, { 0, 0, 0, 255 })
 end
 
 function lightCalbak(fov, x, y)
@@ -17,7 +17,7 @@ end
 function computeCalbak(x, y, r, v)
     local key  =x..','..y
     if not map[key] then return end
-    local color= {r=121, g=121, b=0, a=255}
+    local color= { 121, 121, 0, 255 }
     f:write(r>0 and f:getCharacter(x, y) or '@', x, y, nil, color)
 end
 local player={x=1, y=1}

--- a/examples/color.lua
+++ b/examples/color.lua
@@ -1,30 +1,29 @@
 ROT=require 'src.rot'
 function love.load()
-    colorHandler=ROT.Color:new()
     f=ROT.Display()
     local s=''
     for i=1,80 do s=s..' ' end
 
-    grey=colorHandler:fromString('grey')
+    grey=ROT.Color:fromString('grey')
 
-    c1=colorHandler:fromString('rgb(10, 128, 230)')
-    c2=colorHandler:fromString('#faa')
-    c3=colorHandler:fromString('#83fcc4')
-    c4=colorHandler:fromString('goldenrod')
-    c5={r=51,g=102,b=51,a=255}
-    c6=colorHandler:add({r=10,g=128,b=230,a=255}, {{r=200,g=10,b=15,a=255},{r=30,g=30,b=100,a=255}})
-    c7=colorHandler:multiply(colorHandler:fromString('goldenrod'),
-                             {colorHandler:fromString('lightcyan'),
-                              colorHandler:fromString('lightcoral')})
-    c8=colorHandler:interpolate({r=200,g=10,b=15,a=255},{r=30,g=30,b=100,a=255})
-    c9=colorHandler:interpolateHSL({r=200,g=10,b=15,a=255},{r=30,g=30,b=100,a=255})
+    c1=ROT.Color:fromString('rgb(10, 128, 230)')
+    c2=ROT.Color:fromString('#faa')
+    c3=ROT.Color:fromString('#83fcc4')
+    c4=ROT.Color:fromString('goldenrod')
+    c5={ 51, 102, 51, 255 }
+    c6=ROT.Color:add({ 10, 128, 230, 255 }, { 200, 10, 15, 255 }, { 30, 30, 100, 255 })
+    c7=ROT.Color:multiply(ROT.Color:fromString('goldenrod'),
+                             ROT.Color:fromString('lightcyan'),
+                              ROT.Color:fromString('lightcoral'))
+    c8=ROT.Color:interpolate({ 200, 10, 15, 255 },{ 30, 30, 100, 255 })
+    c9=ROT.Color:interpolateHSL({ 200, 10, 15, 255 },{ 30, 30, 100, 255 })
 
-    c10=colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})
-    c11=colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})
-    c12=colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})
-    c13=colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})
+    c10=ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})
+    c11=ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})
+    c12=ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})
+    c13=ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})
 
-    c14=colorHandler:fromString('silver')
+    c14=ROT.Color:fromString('silver')
 
     f:write(s, 1, 1, nil, c1)
     f:write(s, 1, 2, nil, c2)
@@ -52,18 +51,18 @@ function love.load()
     f:write(s, 1,24, nil, c14)
 
     -- generating a color object from a string
-    f:writeCenter("colorHandler:fromString('rgb(10, 128, 230)')", 1, nil, c1)
-    f:writeCenter("colorHandler:fromString('#faa')", 2, grey, c2)
-    f:writeCenter("colorHandler:fromString('#83fcc4')", 3, grey, c3)
-    f:writeCenter("colorHandler:fromString('goldenrod')", 4, grey, c4)
+    f:writeCenter("ROT.Color:fromString('rgb(10, 128, 230)')", 1, nil, c1)
+    f:writeCenter("ROT.Color:fromString('#faa')", 2, grey, c2)
+    f:writeCenter("ROT.Color:fromString('#83fcc4')", 3, grey, c3)
+    f:writeCenter("ROT.Color:fromString('goldenrod')", 4, grey, c4)
 
     -- Converting a color object to a string
-    f:writeCenter("colorHandler:toRGB({r=10, g=128, b=230, a=255})=="..colorHandler:toRGB({r=10, g=128, b=230}), 5, nil, c1)
-    f:writeCenter("colorHandler:toHex({r=10, g=128, b=230, a=255})=="..colorHandler:toHex({r=10, g=128, b=230}), 6, nil, c1)
+    f:writeCenter("ROT.Color:toRGB({ 10, 128, 230, 255 })=="..ROT.Color:toRGB({ 10, 128, 230 }), 5, nil, c1)
+    f:writeCenter("ROT.Color:toHex({ 10, 128, 230, 255 })=="..ROT.Color:toHex({ 10, 128, 230 }), 6, nil, c1)
 
     -- converting a color from rgb to hsl
-    f:writeCenter("colorHandler:rgb2hsl({r=51, g=102, b=51, a=255})", 7, nil, c5)
-    local tbl=colorHandler:rgb2hsl({r=51, g=102, b=51, a=255})
+    f:writeCenter("ROT.Color:rgb2hsl({ 51, 102, 51, 255 })", 7, nil, c5)
+    local tbl=ROT.Color:rgb2hsl({ 51, 102, 51, 255 })
     local s="{"
     for k,_ in pairs(tbl) do
         s=s..k.."="..tbl[k]..", "
@@ -72,8 +71,8 @@ function love.load()
     f:writeCenter(s, 8, nil, c5)
 
     -- and back!
-    f:writeCenter("colorHandler:hsl2rgb({h=.333, s=.333, l=.3})", 9, nil, c5)
-    local tbl=colorHandler:hsl2rgb({h=.333, s=.333, l=.3})
+    f:writeCenter("ROT.Color:hsl2rgb({ .333, .333, .3 })", 9, nil, c5)
+    local tbl=ROT.Color:hsl2rgb({ .333, .333, .3 })
     local s="{"
     for k,_ in pairs(tbl) do
         s=s..k.."="..tbl[k]..", "
@@ -84,28 +83,28 @@ function love.load()
     -- Adding two or more colors
         -- arg1 is the base color
         -- arg2 is either a second color or a table of colors (This also applies to multiply)
-    f:write("add({r=10,g=128,b=230,a=255}, {{r=200,g=10,b=15,a=255},{r=30,g=30,b=100,a=255}})", 1, 11, nil, c6)
-    local s=colorHandler:toRGB(c6)
+    f:write("add({ 10, 128, 230, 255 }, { 200, 10, 15, 255 }, { 30, 30, 100, 255 })", 1, 11, nil, c6)
+    local s=ROT.Color:toRGB(c6)
     f:writeCenter(s, 12, nil, c6)
 
     -- Multiplying two or more colors
-    f:write("colorHandler:multiply(colorHandler:fromString('goldenrod'),", 1, 13, nil, c7)
-    f:write("                     {colorHandler:fromString('lightcyan'),", 1, 14, nil, c7)
-    f:write("                      colorHandler:fromString('lightcoral')})", 1, 15, nil, c7)
+    f:write("ROT.Color:multiply(ROT.Color:fromString('goldenrod'),", 1, 13, nil, c7)
+    f:write("                     {ROT.Color:fromString('lightcyan'),", 1, 14, nil, c7)
+    f:write("                      ROT.Color:fromString('lightcoral')})", 1, 15, nil, c7)
 
     -- Interpolate 2 colors
-    f:write("colorHandler:interpolate({r=200,g=10,b=15,a=255},{r=30,g=30,b=100,a=255})", 1, 16, nil, c8)
+    f:write("ROT.Color:interpolate({ 200, 10, 15, 255 },{ 30, 30, 100, 255 })", 1, 16, nil, c8)
 
     -- Interpolate 2 colors in HSL mode
-    f:write("colorHandler:interpolateHSL({r=200,g=10,b=15,a=255},{r=30,g=30,b=100,a=255})", 1, 17, nil, c9)
+    f:write("ROT.Color:interpolateHSL({ 200, 10, 15, 255 },{ 30, 30, 100, 255 })", 1, 17, nil, c9)
 
     -- Randomize Color from a reference and standard deviation
-    f:writeCenter("colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})", 18, nil, c10)
-    f:writeCenter("colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})", 19, nil, c11)
-    f:writeCenter("colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})", 20, nil, c12)
-    f:writeCenter("colorHandler:randomize(colorHandler:fromString('silver'), {30,10,20})", 21, nil, c13)
+    f:writeCenter("ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})", 18, nil, c10)
+    f:writeCenter("ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})", 19, nil, c11)
+    f:writeCenter("ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})", 20, nil, c12)
+    f:writeCenter("ROT.Color:randomize(ROT.Color:fromString('silver'), {30,10,20})", 21, nil, c13)
 
-    f:writeCenter("colorHandler:fromString('silver')", 23, nil, c14)
+    f:writeCenter("ROT.Color:fromString('silver')", 23, nil, c14)
 
 end
 function love.draw() f:draw() end

--- a/examples/dijkstra.lua
+++ b/examples/dijkstra.lua
@@ -38,14 +38,14 @@ function doTheThing()
     start=os.clock()
     dijkstra:compute(p3[1], p3[2], dijkstraCallback)
 
-    f:write('S', tonumber(p1[1]), tonumber(p1[2]), nil, {r=0, g=0, b=255, a=255})
-    f:write('E', tonumber(p2[1]), tonumber(p2[2]), nil, {r=0, g=0, b=255, a=255})
-    f:write('E', tonumber(p3[1]), tonumber(p3[2]), nil, {r=0, g=0, b=255, a=255})
+    f:write('S', tonumber(p1[1]), tonumber(p1[2]), nil, { 0, 0, 255, 255 })
+    f:write('E', tonumber(p2[1]), tonumber(p2[2]), nil, { 0, 0, 255, 255 })
+    f:write('E', tonumber(p3[1]), tonumber(p3[2]), nil, { 0, 0, 255, 255 })
 
 end
 
 function dijkstraCallback(x, y)
-    f:write('.', x, y, nil, {r=136, g=0, b=0, a=255})
+    f:write('.', x, y, nil, { 136, 0, 0, 255 })
 end
 
 function passableCallback(x, y) return data[x..','..y]==0 end

--- a/examples/dijkstraMap.lua
+++ b/examples/dijkstraMap.lua
@@ -1,12 +1,11 @@
 --[[ Rogue ]]
 ROT=require 'src.rot'
 movers={}
-clr=ROT.Color:new()
 colors={}
-table.insert(colors, clr:fromString('blue'))
-table.insert(colors, clr:fromString('red'))
-table.insert(colors, clr:fromString('green'))
-table.insert(colors, clr:fromString('yellow'))
+table.insert(colors, ROT.Color:fromString('blue'))
+table.insert(colors, ROT.Color:fromString('red'))
+table.insert(colors, ROT.Color:fromString('green'))
+table.insert(colors, ROT.Color:fromString('yellow'))
 function love.load()
     f  =ROT.Display()
     maps={
@@ -28,11 +27,11 @@ function love.update(dt)
         for _,mover in pairs(movers) do
             local dir={dijkMap:dirTowardsGoal(mover.x, mover.y)}
             if dir[1] and dir[2] and mover.x and mover.y then
-                f:write(map[mover.x][mover.y], mover.x, mover.y, nil, clr:interpolate(mover.color, mover.oc))
+                f:write(map[mover.x][mover.y], mover.x, mover.y, nil, ROT.Color:interpolate(mover.color, mover.oc))
                 mover.x=mover.x+dir[1]
                 mover.y=mover.y+dir[2]
                 local oc=f:getBackgroundColor(mover.x, mover.y)
-                mover.oc=oc==f:getDefaultBackgroundColor() and clr:fromString('dimgrey') or oc
+                mover.oc=oc==f:getDefaultBackgroundColor() and ROT.Color:fromString('dimgrey') or oc
                 f:write('@', mover.x, mover.y, nil, mover.color)
             end
         end
@@ -84,7 +83,7 @@ function dothething()
         mover.y=mover.y+dir[2]
         local x=mover.x
         local y=mover.y
-        f:write(map[x][y], x, y, nil, {r=125,g=15,b=15,a=255})
+        f:write(map[x][y], x, y, nil, { 125, 15, 15, 255 })
     end--]]
 end
 
@@ -97,8 +96,8 @@ end
 function dijkCalbak(x,y) return map[x][y]=='.' end
 
 function getRandomColor()
-    return { r=math.floor(ROT.RNG:random(0,255)),
-             g=math.floor(ROT.RNG:random(0,255)),
-             b=math.floor(ROT.RNG:random(0,255)),
-             a=255}
+    return { math.floor(ROT.RNG:random(0,255)),
+             math.floor(ROT.RNG:random(0,255)),
+             math.floor(ROT.RNG:random(0,255)),
+             255}
 end

--- a/examples/ellerMaze.lua
+++ b/examples/ellerMaze.lua
@@ -7,7 +7,7 @@ end
 function love.draw() f:draw() end
 ellerStr=''
 function calbak(x,y,val)
-	f:write(' ', x, y, nil, val==0 and {r=125, g=125, b=125, a=255} or nil)
+	f:write(' ', x, y, nil, val==0 and { 125, 125, 125, 255 } or nil)
 end
 local update=false
 function love.update()

--- a/examples/lighting.lua
+++ b/examples/lighting.lua
@@ -2,7 +2,6 @@ ROT=require 'src.rot'
 
 function love.load()
     f=ROT.Display(80, 24)
-    colorhandler=ROT.Color:new()
     maps={
         "Arena",
         "DividedMaze",
@@ -53,18 +52,18 @@ function doTheThing()
         lighting:setLight(tonumber(point[1]),tonumber(point[2]), getRandomColor())
     end
     lighting:compute(lightingCallback)
-    local ambientLight={r=0, g=0, b=0, a=255}
+    local ambientLight={ 0, 0, 0, 255 }
     for k,_ in pairs(mapData) do
         local parts=k:split(',')
         local x    =tonumber(parts[1])
         local y    =tonumber(parts[2])
-        local baseColor=mapData[k]==floorValue and {r=125, g=125, b=125, a=255} or {r=50, g=50, b=50, a=255}
+        local baseColor=mapData[k]==floorValue and { 125, 125, 125, 255 } or { 50, 50, 50, 255 }
         local light=ambientLight
         local char=f:getCharacter(x, y)
         if lightData[k] then
-            light=colorhandler:add(light, lightData[k])
+            light=ROT.Color:add(light, lightData[k])
         end
-        local finalColor=colorhandler:multiply(baseColor, light)
+        local finalColor=ROT.Color:multiply(baseColor, light)
         char=not lightData[k] and ' ' or char~=' ' and char or mapData[x..','..y]~=floorValue and '#' or ' '
 
         f:write(char, x, y, light, finalColor)

--- a/examples/precise.lua
+++ b/examples/precise.lua
@@ -17,7 +17,7 @@ end
 function computeCalbak(x, y, r, v)
     local key  =x..','..y
     if not map[key] then return end
-    local color= {r=121, g=121, b=0, a=255}
+    local color= { 121, 121, 0, 255 }
     f:write(r>0 and f:getCharacter(x, y) or '@', x, y, nil, color)
 end
 local player={x=1, y=1}

--- a/examples/preciseWithMovingPlayer.lua
+++ b/examples/preciseWithMovingPlayer.lua
@@ -43,9 +43,9 @@ function love.load()
     map={}
     field={}
     seen={}
-    seenColor={r=100, g=100, b=100, a=255}
-    fieldColor={r=225, g=225, b=225, a=255}
-    fieldbg={r=50, g=50, b=50, a=255}
+    seenColor={ 100, 100, 100, 255 }
+    fieldColor={ 225, 225, 225, 255 }
+    fieldbg={ 50, 50, 50, 255 }
     update=false
     player={x=1, y=1}
     doTheThing()

--- a/examples/simplex.lua
+++ b/examples/simplex.lua
@@ -8,7 +8,7 @@ function generateNoise()
             red  =math.floor(val>0 and val or 0)
             green=math.floor(val<0 and -val or 0)
 
-            f:write(' ', i, j, nil, {r=red, g=green, b=0, a=255})
+            f:write(' ', i, j, nil, { red, green, 0, 255 })
         end
     end
 end

--- a/examples/textDisplay.lua
+++ b/examples/textDisplay.lua
@@ -20,9 +20,9 @@
     end
 
     function getRandomColor()
-        return { r=math.floor(ROT.RNG:random(0,255)),
-                 g=math.floor(ROT.RNG:random(0,255)),
-                 b=math.floor(ROT.RNG:random(0,255)),
-                 a=255}
+        return { math.floor(ROT.RNG:random(0,255)),
+                 math.floor(ROT.RNG:random(0,255)),
+                 math.floor(ROT.RNG:random(0,255)),
+                 255}
     end
 --]]

--- a/src/rot/color.lua
+++ b/src/rot/color.lua
@@ -7,281 +7,82 @@
 local ROT = require((...):gsub(('.[^./\\]*'):rep(1) .. '$', ''))
 local Color = ROT.Class:extend("Color")
 
-function Color:init()
-    self._cached={
-			black= {r=0,g=0,b=0,a=255},
-			navy= {r=0,g=0,b=128,a=255},
-			darkblue= {r=0,g=0,b=139,a=255},
-			mediumblue= {r=0,g=0,b=205,a=255},
-			blue= {r=0,g=0,b=255,a=255},
-			darkgreen= {r=0,g=100,b=0,a=255},
-			green= {r=0,g=128,b=0,a=255},
-			teal= {r=0,g=128,b=128,a=255},
-			darkcyan= {r=0,g=139,b=139,a=255},
-			deepskyblue= {r=0,g=191,b=255,a=255},
-			darkturquoise= {r=0,g=206,b=209,a=255},
-			mediumspringgreen= {r=0,g=250,b=154,a=255},
-			lime= {r=0,g=255,b=0,a=255},
-			springgreen= {r=0,g=255,b=127,a=255},
-			aqua= {r=0,g=255,b=255,a=255},
-			cyan= {r=0,g=255,b=255,a=255},
-			midnightblue= {r=25,g=25,b=112,a=255},
-			dodgerblue= {r=30,g=144,b=255,a=255},
-			forestgreen= {r=34,g=139,b=34,a=255},
-			seagreen= {r=46,g=139,b=87,a=255},
-			darkslategray= {r=47,g=79,b=79,a=255},
-			darkslategrey= {r=47,g=79,b=79,a=255},
-			limegreen= {r=50,g=205,b=50,a=255},
-			mediumseagreen= {r=60,g=179,b=113,a=255},
-			turquoise= {r=64,g=224,b=208,a=255},
-			royalblue= {r=65,g=105,b=225,a=255},
-			steelblue= {r=70,g=130,b=180,a=255},
-			darkslateblue= {r=72,g=61,b=139,a=255},
-			mediumturquoise= {r=72,g=209,b=204,a=255},
-			indigo= {r=75,g=0,b=130,a=255},
-			darkolivegreen= {r=85,g=107,b=47,a=255},
-			cadetblue= {r=95,g=158,b=160,a=255},
-			cornflowerblue= {r=100,g=149,b=237,a=255},
-			mediumaquamarine= {r=102,g=205,b=170,a=255},
-			dimgray= {r=105,g=105,b=105,a=255},
-			dimgrey= {r=105,g=105,b=105,a=255},
-			slateblue= {r=106,g=90,b=205,a=255},
-			olivedrab= {r=107,g=142,b=35,a=255},
-			slategray= {r=112,g=128,b=144,a=255},
-			slategrey= {r=112,g=128,b=144,a=255},
-			lightslategray= {r=119,g=136,b=153,a=255},
-			lightslategrey= {r=119,g=136,b=153,a=255},
-			mediumslateblue= {r=123,g=104,b=238,a=255},
-			lawngreen= {r=124,g=252,b=0,a=255},
-			chartreuse= {r=127,g=255,b=0,a=255},
-			aquamarine= {r=127,g=255,b=212,a=255},
-			maroon= {r=128,g=0,b=0,a=255},
-			purple= {r=128,g=0,b=128,a=255},
-			olive= {r=128,g=128,b=0,a=255},
-			gray= {r=128,g=128,b=128,a=255},
-			grey= {r=128,g=128,b=128,a=255},
-			skyblue= {r=135,g=206,b=235,a=255},
-			lightskyblue= {r=135,g=206,b=250,a=255},
-			blueviolet= {r=138,g=43,b=226,a=255},
-			darkred= {r=139,g=0,b=0,a=255},
-			darkmagenta= {r=139,g=0,b=139,a=255},
-			saddlebrown= {r=139,g=69,b=19,a=255},
-			darkseagreen= {r=143,g=188,b=143,a=255},
-			lightgreen= {r=144,g=238,b=144,a=255},
-			mediumpurple= {r=147,g=112,b=216,a=255},
-			darkviolet= {r=148,g=0,b=211,a=255},
-			palegreen= {r=152,g=251,b=152,a=255},
-			darkorchid= {r=153,g=50,b=204,a=255},
-			yellowgreen= {r=154,g=205,b=50,a=255},
-			sienna= {r=160,g=82,b=45,a=255},
-			brown= {r=165,g=42,b=42,a=255},
-			darkgray= {r=169,g=169,b=169,a=255},
-			darkgrey= {r=169,g=169,b=169,a=255},
-			lightblue= {r=173,g=216,b=230,a=255},
-			greenyellow= {r=173,g=255,b=47,a=255},
-			paleturquoise= {r=175,g=238,b=238,a=255},
-			lightsteelblue= {r=176,g=196,b=222,a=255},
-			powderblue= {r=176,g=224,b=230,a=255},
-			firebrick= {r=178,g=34,b=34,a=255},
-			darkgoldenrod= {r=184,g=134,b=11,a=255},
-			mediumorchid= {r=186,g=85,b=211,a=255},
-			rosybrown= {r=188,g=143,b=143,a=255},
-			darkkhaki= {r=189,g=183,b=107,a=255},
-			silver= {r=192,g=192,b=192,a=255},
-			mediumvioletred= {r=199,g=21,b=133,a=255},
-			indianred= {r=205,g=92,b=92,a=255},
-			peru= {r=205,g=133,b=63,a=255},
-			chocolate= {r=210,g=105,b=30,a=255},
-			tan= {r=210,g=180,b=140,a=255},
-			lightgray= {r=211,g=211,b=211,a=255},
-			lightgrey= {r=211,g=211,b=211,a=255},
-			palevioletred= {r=216,g=112,b=147,a=255},
-			thistle= {r=216,g=191,b=216,a=255},
-			orchid= {r=218,g=112,b=214,a=255},
-			goldenrod= {r=218,g=165,b=32,a=255},
-			crimson= {r=220,g=20,b=60,a=255},
-			gainsboro= {r=220,g=220,b=220,a=255},
-			plum= {r=221,g=160,b=221,a=255},
-			burlywood= {r=222,g=184,b=135,a=255},
-			lightcyan= {r=224,g=255,b=255,a=255},
-			lavender= {r=230,g=230,b=250,a=255},
-			darksalmon= {r=233,g=150,b=122,a=255},
-			violet= {r=238,g=130,b=238,a=255},
-			palegoldenrod= {r=238,g=232,b=170,a=255},
-			lightcoral= {r=240,g=128,b=128,a=255},
-			khaki= {r=240,g=230,b=140,a=255},
-			aliceblue= {r=240,g=248,b=255,a=255},
-			honeydew= {r=240,g=255,b=240,a=255},
-			azure= {r=240,g=255,b=255,a=255},
-			sandybrown= {r=244,g=164,b=96,a=255},
-			wheat= {r=245,g=222,b=179,a=255},
-			beige= {r=245,g=245,b=220,a=255},
-			whitesmoke= {r=245,g=245,b=245,a=255},
-			mintcream= {r=245,g=255,b=250,a=255},
-			ghostwhite= {r=248,g=248,b=255,a=255},
-			salmon= {r=250,g=128,b=114,a=255},
-			antiquewhite= {r=250,g=235,b=215,a=255},
-			linen= {r=250,g=240,b=230,a=255},
-			lightgoldenrodyellow= {r=250,g=250,b=210,a=255},
-			oldlace= {r=253,g=245,b=230,a=255},
-			red= {r=255,g=0,b=0,a=255},
-			fuchsia= {r=255,g=0,b=255,a=255},
-			magenta= {r=255,g=0,b=255,a=255},
-			deeppink= {r=255,g=20,b=147,a=255},
-			orangered= {r=255,g=69,b=0,a=255},
-			tomato= {r=255,g=99,b=71,a=255},
-			hotpink= {r=255,g=105,b=180,a=255},
-			coral= {r=255,g=127,b=80,a=255},
-			darkorange= {r=255,g=140,b=0,a=255},
-			lightsalmon= {r=255,g=160,b=122,a=255},
-			orange= {r=255,g=165,b=0,a=255},
-			lightpink= {r=255,g=182,b=193,a=255},
-			pink= {r=255,g=192,b=203,a=255},
-			gold= {r=255,g=215,b=0,a=255},
-			peachpuff= {r=255,g=218,b=185,a=255},
-			navajowhite= {r=255,g=222,b=173,a=255},
-			moccasin= {r=255,g=228,b=181,a=255},
-			bisque= {r=255,g=228,b=196,a=255},
-			mistyrose= {r=255,g=228,b=225,a=255},
-			blanchedalmond= {r=255,g=235,b=205,a=255},
-			papayawhip= {r=255,g=239,b=213,a=255},
-			lavenderblush= {r=255,g=240,b=245,a=255},
-			seashell= {r=255,g=245,b=238,a=255},
-			cornsilk= {r=255,g=248,b=220,a=255},
-			lemonchiffon= {r=255,g=250,b=205,a=255},
-			floralwhite= {r=255,g=250,b=240,a=255},
-			snow= {r=255,g=250,b=250,a=255},
-			yellow= {r=255,g=255,b=0,a=255},
-			lightyellow= {r=255,g=255,b=224,a=255},
-			ivory= {r=255,g=255,b=240,a=255},
-			white= {r=255,g=255,b=255,a=255}
-	}
-end
-
 --- Get color from string.
 -- Convert one of several formats of string to what
 -- Color interperets as a color object
 -- @tparam string str Accepted formats 'rgb(0..255, 0..255, 0..255)', '#5fe', '#5FE', '#254eff', 'goldenrod'
 function Color:fromString(str)
-    local cached={r=0,g=0,b=0,a=255}
-    if self._cached[str] then cached = self._cached[str]
-    else
-        local values={}
-        if str:sub(1,1) == '#' then
-            local i=1
-            for s in str:gmatch('[%da-fA-F]') do
-                values[i]=tonumber(s, 16)
-                i=i+1
-            end
-            if #values==3 then
-                for i=1,3 do values[i]=values[i]*17 end
-            else
-                for i=1,3 do
-                    values[i+1]=values[i+1]+(16*values[i])
-                    table.remove(values, i)
-                end
-            end
-        elseif str:gmatch('rgb') then
-            local i=1
-            for s in str:gmatch('(%d+)') do
-                values[i]=tonumber(s)
-                i=i+1
+    local cached = self._cached[str]
+    if cached then return cached end
+    local values = { 0, 0, 0 }
+    if str:sub(1,1) == '#' then
+        local i=1
+        for s in str:gmatch('[%da-fA-F]') do
+            values[i]=tonumber(s, 16)
+            i=i+1
+        end
+        if #values==3 then
+            for i=1,3 do values[i]=values[i]*17 end
+        else
+            for i=1, 3 do
+                values[i+1]=values[i+1]+(16*values[i])
+                table.remove(values, i)
             end
         end
-        cached.r=values[1]
-        cached.g=values[2]
-        cached.b=values[3]
+    elseif str:gmatch('rgb') then
+        local i=1
+        for s in str:gmatch('(%d+)') do
+            values[i]=tonumber(s)
+            i=i+1
+        end
     end
-    self._cached[str]=cached
-    return {r=cached.r, g=cached.g, b=cached.b, a=cached.a}
+    self._cached[str] = values
+    return values
+end
+
+local function add(t, color, ...)
+    if not color then return t end
+    for i = 1, #color do
+        t[i] = (t[i] or 0) + color[i]
+    end
+    return add(t, ...)
+end
+
+local function multiply(t, color, ...)
+    if not color then return t end
+    for i = 1, #color do
+        t[i] = math.floor((t[i] or 255) * color[i] / 255 + 0.5)
+    end
+    return multiply(t, ...)
 end
 
 --- Add two or more colors.
--- accepts either (color, color) or (color, tableOfColors)
 -- @tparam table color1 A color table
--- @tparam table color2 A color table or a table of color tables.
--- @treturn table resulting color
-function Color:add(color1, color2)
-    local result={}
-    for k,_ in pairs(color1) do result[k]=color1[k] end
-    if color2.r then
-        for k,_ in pairs(color2) do
-            result[k]=result[k]+color2[k]
-        end
-    elseif color2[1].r then
-        for k,_ in pairs(color2) do
-            for l,_ in pairs(color2[k]) do
-                assert(result[l])
-                result[l]=result[l]+color2[k][l]
-            end
-        end
-    end
-    return result
-end
+-- @tparam table color2 A color table
+-- @tparam table ... More color tables
+-- @treturn table new color
+function Color:add(...) return add({}, ...) end
 
---- Add two or more colors.
--- accepts either (color, color) or (color, tableOfColors)
--- Modifies first arg
+--- Add two or more colors. Modifies first color in-place.
 -- @tparam table color1 A color table
--- @tparam table color2 A color table or a table of color tables.
--- @treturn table resulting color
-function Color:add_(color1, color2)
-    if color2.r then
-        for k,_ in pairs(color2) do
-            color1[k]=color1[k]+color2[k]
-        end
-    elseif color2[1].r then
-        for k,_ in pairs(color2) do
-            for l,_ in pairs(color2[k]) do
-                color1[l]=color1[l]+color2[k][l]
-            end
-        end
-    end
-    return color1
-end
+-- @tparam table color2 A color table
+-- @tparam table ... More color tables
+-- @treturn table modified color
+function Color:add_(...) return add(...) end
 
--- multiply (mix) two or more colors.
--- accepts either (color, color) or (color, tableOfColors)
+-- Multiply (mix) two or more colors.
 -- @tparam table color1 A color table
--- @tparam table color2 A color table or a table of color tables.
--- @treturn table resulting color
-function Color:multiply(color1, color2)
-    local result={}
-    for k,_ in pairs(color1) do result[k]=color1[k] end
-    if color2.r then
-        for k,_ in pairs(color2) do
-            result[k]=math.round(result[k]*color2[k]/255)
-        end
-    elseif color2[1].r then
-        for k,_ in pairs(color2) do
-            for l,_ in pairs(color2[k]) do
-                result[l]=math.round(result[l]*color2[k][l]/255)
-            end
-        end
-    end
-    return result
-end
+-- @tparam table color2 A color table
+-- @tparam table ... More color tables
+-- @treturn table new color
+function Color:multiply(...) return multiply({}, ...) end
 
--- multiply (mix) two or more colors.
--- accepts either (color, color) or (color, tableOfColors)
--- Modifies first arg
+-- Multiply (mix) two or more colors. Modifies first color in-place.
 -- @tparam table color1 A color table
--- @tparam table color2 A color table or a table of color tables.
--- @treturn table resulting color
-function Color:multiply_(color1, color2)
-    if color2.r then
-        for k,_ in pairs(color2) do
-            color1[k]=math.round(color1[k]*color2[k]/255)
-        end
-    elseif color2[1].r then
-        for k,_ in pairs(color2) do
-            for l,_ in pairs(color2[k]) do
-                color1[l]=math.round(color1[l]*color2[k][l]/255)
-            end
-        end
-    end
-    return color1
-end
+-- @tparam table color2 A color table
+-- @tparam table ... More color tables
+-- @treturn table modified color
+function Color:multiply_(...) return multiply(...) end
 
 --- Interpolate (blend) two colors with a given factor.
 -- @tparam table color1 A color table
@@ -289,11 +90,11 @@ end
 -- @tparam float factor A number from 0 to 1. <0.5 favors color1, >0.5 favors color2.
 -- @treturn table resulting color
 function Color:interpolate(color1, color2, factor)
-    factor=factor and factor or .5
+    factor = factor or .5
     local result={}
-    for k,_ in pairs(color1) do result[k]=color1[k] end
-    for k,_ in pairs(color2) do
-        result[k]=math.round(result[k] + factor*(color2[k]-color1[k]))
+    for i = 1, math.max(#color1, #color2) do
+        local a, b = color2[i] or color1[i], color1[i] or color2[i]
+        result[i] = math.floor(b + factor*(a-b) + 0.5)
     end
     return result
 end
@@ -304,13 +105,14 @@ end
 -- @tparam float factor A number from 0 to 1. <0.5 favors color1, >0.5 favors color2.
 -- @treturn table resulting color
 function Color:interpolateHSL(color1, color2, factor)
-    factor=factor and factor or .5
-    local hsl1 = self:rgb2hsl(color1)
-    local hsl2 = self:rgb2hsl(color2)
-    for k,_ in pairs(hsl2) do
-        hsl1[k]= hsl1[k] + factor*(hsl2[k]-hsl1[k])
+    factor = factor or .5
+    local result={}
+    local hsl1, hsl2 = self:rgb2hsl(color1), self:rgb2hsl(color2)
+    for i = 1, math.max(#hsl1, #hsl2) do
+        local a, b = hsl2[i] or hsl1[i], hsl1[i] or hsl2[i]
+        result[i] = b + factor*(a-b)
     end
-    return self:hsl2rgb(hsl1)
+    return self:hsl2rgb(result)
 end
 
 --- Create a new random color based on this one
@@ -318,24 +120,25 @@ end
 -- @tparam int|table diff One or more numbers to use for a standard deviation
 function Color:randomize(color, diff)
     local result={}
-    for k,_ in pairs(color) do result[k]=color[k] end
     if type(diff) ~= 'table' then
-        diff=self._rng:random(0,diff)
-        for k,_ in pairs(result) do result[k]=result[k]+diff end
+        local diff = self._rng:random(0, diff)
+        for i = 1, #color do
+            result[i] = color[i] + diff
+        end
     else
-        assert(#diff>2, 'Color:randomize() can use a table of standard deviations, but it requires at least 3 elements in said table.')
-        result.r=result.r+self._rng:random(0,diff[1])
-        result.g=result.g+self._rng:random(0,diff[2])
-        result.b=result.b+self._rng:random(0,diff[3])
+        for i = 1, #color do
+            result[i] = color[i] + self._rng:random(0, diff[i])
+        end
     end
     return result
 end
 
 -- Convert rgb color to hsl
 function Color:rgb2hsl(color)
-    local r=color.r/255
-    local g=color.g/255
-    local b=color.b/255
+    local r=color[1]/255
+    local g=color[2]/255
+    local b=color[3]/255
+    local a=color[4] and color[4]/255
     local max=math.max(r, g, b)
     local min=math.min(r, g, b)
     local h,s,l=0,0,(max+min)/2
@@ -350,70 +153,69 @@ function Color:rgb2hsl(color)
         elseif max==b then
             h=(r-g)/ d + 4
         end
-            h=h/6
+        h=h/6
     end
-    local result={}
-    result.h=h
-    result.s=s
-    result.l=l
-    return result
+    
+    return { h, s, l, a }
 end
 
+local function hue2rgb(p, q, t)
+    if t<0 then t=t+1 end
+    if t>1 then t=t-1 end
+    if t<1/6 then return (p+(q-p)*6*t) end
+    if t<1/2 then return q end
+    if t<2/3 then return (p+(q-p)*(2/3-t)*6) end
+    return p
+end
+        
 -- Convert hsl color to rgb
 function Color:hsl2rgb(color)
-    local result={r=0, g=0, b=0, a=255}
-    if color.s==0 then
-        for k,_ in pairs(result) do
-            result[k]=color.l*255
+    local h, s, l = color[1], color[2], color[3]
+    local result = {}
+    result[4] = color[4] and math.floor(color[4] * 255)
+    if s == 0 then
+        local value = math.floor(l * 255 + 0.5)
+        for i = 1, 3 do
+            result[i] = value
         end
-        result.a=255
-        return result
     else
-        local function hue2rgb(p, q, t)
-            if t<0 then t=t+1 end
-            if t>1 then t=t-1 end
-            if t<1/6 then return (p+(q-p)*6*t) end
-            if t<1/2 then return q end
-            if t<2/3 then return (p+(q-p)*(2/3-t)*6) end
-            return p
-        end
-        local s=color.s
-        local l=color.l
         local q=l<.5 and l*(1+s) or l+s-l*s
         local p=2*l-q
-        result.r=math.round(hue2rgb(p,q,color.h+1/3)*255)
-        result.g=math.round(hue2rgb(p,q,color.h)*255)
-        result.b=math.round(hue2rgb(p,q,color.h-1/3)*255)
-        result.a=255
-        return result
+        result[1] = math.floor(hue2rgb(p,q,h+1/3)*255 + 0.5)
+        result[2] = math.floor(hue2rgb(p,q,h)*255 + 0.5)
+        result[3] = math.floor(hue2rgb(p,q,h-1/3)*255 + 0.5)
     end
+    return result
 end
 
 --- Convert color to RGB string.
 -- Get a string that can be fed to Color:fromString()
 -- @tparam table color A color table
 function Color:toRGB(color)
-    return 'rgb('..self:_clamp(color.r)..','..self:_clamp(color.g)..','..self:_clamp(color.b)..')'
+    return 'rgb('..
+        self:_clamp(color[1])..','..
+        self:_clamp(color[2])..','..
+        self:_clamp(color[3])..')'
 end
 
+local function dec2hex(IN) -- thanks Lostgallifreyan(http://lua-users.org/lists/lua-l/2004-09/msg00054.html)
+    local B,K,OUT,I,D=16,"0123456789abcdef","",0
+    while IN>0 do
+        I=I+1
+        IN,D=math.floor(IN/B),math.mod(IN,B)+1
+        OUT=string.sub(K,D,D)..OUT
+    end
+    return OUT
+end
+    
 --- Convert color to Hex string
 -- Get a string that can be fed to Color:fromString()
 -- @tparam table color A color table
 function Color:toHex(color)
-    local function dec2hex(IN) -- thanks Lostgallifreyan(http://lua-users.org/lists/lua-l/2004-09/msg00054.html)
-        local B,K,OUT,I,D=16,"0123456789ABCDEF","",0
-        while IN>0 do
-            I=I+1
-            IN,D=math.floor(IN/B),math.mod(IN,B)+1
-            OUT=string.sub(K,D,D)..OUT
-        end
-        return OUT
-    end
-
     local parts={}
-    parts[1]=tostring(dec2hex(self:_clamp(color.r))):lpad('0',2)
-    parts[2]=tostring(dec2hex(self:_clamp(color.g))):lpad('0',2)
-    parts[3]=tostring(dec2hex(self:_clamp(color.b))):lpad('0',2)
+    parts[1]=tostring(dec2hex(self:_clamp(color[1]))):lpad('0',2)
+    parts[2]=tostring(dec2hex(self:_clamp(color[2]))):lpad('0',2)
+    parts[3]=tostring(dec2hex(self:_clamp(color[3]))):lpad('0',2)
     return '#'..table.concat(parts)
 end
 
@@ -422,155 +224,305 @@ function Color:_clamp(n)
     return n<0 and 0 or n>255 and 255 or n
 end
 
+--- Color cache
+-- A table of predefined color tables
+-- These keys can be passed to Color:fromString()
+-- @field black { 0, 0, 0 }
+-- @field navy { 0, 0, 128 }
+-- @field darkblue { 0, 0, 139 }
+-- @field mediumblue { 0, 0, 205 }
+-- @field blue { 0, 0, 255 }
+-- @field darkgreen { 0, 100, 0 }
+-- @field green { 0, 128, 0 }
+-- @field teal { 0, 128, 128 }
+-- @field darkcyan { 0, 139, 139 }
+-- @field deepskyblue { 0, 191, 255 }
+-- @field darkturquoise { 0, 206, 209 }
+-- @field mediumspringgreen { 0, 250, 154 }
+-- @field lime { 0, 255, 0 }
+-- @field springgreen { 0, 255, 127 }
+-- @field aqua { 0, 255, 255 }
+-- @field cyan { 0, 255, 255 }
+-- @field midnightblue { 25, 25, 112 }
+-- @field dodgerblue { 30, 144, 255 }
+-- @field forestgreen { 34, 139, 34 }
+-- @field seagreen { 46, 139, 87 }
+-- @field darkslategray { 47, 79, 79 }
+-- @field darkslategrey { 47, 79, 79 }
+-- @field limegreen { 50, 205, 50 }
+-- @field mediumseagreen { 60, 179, 113 }
+-- @field turquoise { 64, 224, 208 }
+-- @field royalblue { 65, 105, 225 }
+-- @field steelblue { 70, 130, 180 }
+-- @field darkslateblue { 72, 61, 139 }
+-- @field mediumturquoise { 72, 209, 204 }
+-- @field indigo { 75, 0, 130 }
+-- @field darkolivegreen { 85, 107, 47 }
+-- @field cadetblue { 95, 158, 160 }
+-- @field cornflowerblue { 100, 149, 237 }
+-- @field mediumaquamarine { 102, 205, 170 }
+-- @field dimgray { 105, 105, 105 }
+-- @field dimgrey { 105, 105, 105 }
+-- @field slateblue { 106, 90, 205 }
+-- @field olivedrab { 107, 142, 35 }
+-- @field slategray { 112, 128, 144 }
+-- @field slategrey { 112, 128, 144 }
+-- @field lightslategray { 119, 136, 153 }
+-- @field lightslategrey { 119, 136, 153 }
+-- @field mediumslateblue { 123, 104, 238 }
+-- @field lawngreen { 124, 252, 0 }
+-- @field chartreuse { 127, 255, 0 }
+-- @field aquamarine { 127, 255, 212 }
+-- @field maroon { 128, 0, 0 }
+-- @field purple { 128, 0, 128 }
+-- @field olive { 128, 128, 0 }
+-- @field gray { 128, 128, 128 }
+-- @field grey { 128, 128, 128 }
+-- @field skyblue { 135, 206, 235 }
+-- @field lightskyblue { 135, 206, 250 }
+-- @field blueviolet { 138, 43, 226 }
+-- @field darkred { 139, 0, 0 }
+-- @field darkmagenta { 139, 0, 139 }
+-- @field saddlebrown { 139, 69, 19 }
+-- @field darkseagreen { 143, 188, 143 }
+-- @field lightgreen { 144, 238, 144 }
+-- @field mediumpurple { 147, 112, 216 }
+-- @field darkviolet { 148, 0, 211 }
+-- @field palegreen { 152, 251, 152 }
+-- @field darkorchid { 153, 50, 204 }
+-- @field yellowgreen { 154, 205, 50 }
+-- @field sienna { 160, 82, 45 }
+-- @field brown { 165, 42, 42 }
+-- @field darkgray { 169, 169, 169 }
+-- @field darkgrey { 169, 169, 169 }
+-- @field lightblue { 173, 216, 230 }
+-- @field greenyellow { 173, 255, 47 }
+-- @field paleturquoise { 175, 238, 238 }
+-- @field lightsteelblue { 176, 196, 222 }
+-- @field powderblue { 176, 224, 230 }
+-- @field firebrick { 178, 34, 34 }
+-- @field darkgoldenrod { 184, 134, 11 }
+-- @field mediumorchid { 186, 85, 211 }
+-- @field rosybrown { 188, 143, 143 }
+-- @field darkkhaki { 189, 183, 107 }
+-- @field silver { 192, 192, 192 }
+-- @field mediumvioletred { 199, 21, 133 }
+-- @field indianred { 205, 92, 92 }
+-- @field peru { 205, 133, 63 }
+-- @field chocolate { 210, 105, 30 }
+-- @field tan { 210, 180, 140 }
+-- @field lightgray { 211, 211, 211 }
+-- @field lightgrey { 211, 211, 211 }
+-- @field palevioletred { 216, 112, 147 }
+-- @field thistle { 216, 191, 216 }
+-- @field orchid { 218, 112, 214 }
+-- @field goldenrod { 218, 165, 32 }
+-- @field crimson { 220, 20, 60 }
+-- @field gainsboro { 220, 220, 220 }
+-- @field plum { 221, 160, 221 }
+-- @field burlywood { 222, 184, 135 }
+-- @field lightcyan { 224, 255, 255 }
+-- @field lavender { 230, 230, 250 }
+-- @field darksalmon { 233, 150, 122 }
+-- @field violet { 238, 130, 238 }
+-- @field palegoldenrod { 238, 232, 170 }
+-- @field lightcoral { 240, 128, 128 }
+-- @field khaki { 240, 230, 140 }
+-- @field aliceblue { 240, 248, 255 }
+-- @field honeydew { 240, 255, 240 }
+-- @field azure { 240, 255, 255 }
+-- @field sandybrown { 244, 164, 96 }
+-- @field wheat { 245, 222, 179 }
+-- @field beige { 245, 245, 220 }
+-- @field whitesmoke { 245, 245, 245 }
+-- @field mintcream { 245, 255, 250 }
+-- @field ghostwhite { 248, 248, 255 }
+-- @field salmon { 250, 128, 114 }
+-- @field antiquewhite { 250, 235, 215 }
+-- @field linen { 250, 240, 230 }
+-- @field lightgoldenrodyellow { 250, 250, 210 }
+-- @field oldlace { 253, 245, 230 }
+-- @field red { 255, 0, 0 }
+-- @field fuchsia { 255, 0, 255 }
+-- @field magenta { 255, 0, 255 }
+-- @field deeppink { 255, 20, 147 }
+-- @field orangered { 255, 69, 0 }
+-- @field tomato { 255, 99, 71 }
+-- @field hotpink { 255, 105, 180 }
+-- @field coral { 255, 127, 80 }
+-- @field darkorange { 255, 140, 0 }
+-- @field lightsalmon { 255, 160, 122 }
+-- @field orange { 255, 165, 0 }
+-- @field lightpink { 255, 182, 193 }
+-- @field pink { 255, 192, 203 }
+-- @field gold { 255, 215, 0 }
+-- @field peachpuff { 255, 218, 185 }
+-- @field navajowhite { 255, 222, 173 }
+-- @field moccasin { 255, 228, 181 }
+-- @field bisque { 255, 228, 196 }
+-- @field mistyrose { 255, 228, 225 }
+-- @field blanchedalmond { 255, 235, 205 }
+-- @field papayawhip { 255, 239, 213 }
+-- @field lavenderblush { 255, 240, 245 }
+-- @field seashell { 255, 245, 238 }
+-- @field cornsilk { 255, 248, 220 }
+-- @field lemonchiffon { 255, 250, 205 }
+-- @field floralwhite { 255, 250, 240 }
+-- @field snow { 255, 250, 250 }
+-- @field yellow { 255, 255, 0 }
+-- @field lightyellow { 255, 255, 224 }
+-- @field ivory { 255, 255, 240 }
+-- @field white { 255, 255, 255 }
+-- @table Color._cache
+    
+Color._cached={
+	black= { 0,  0, 0 },
+	navy= { 0, 0, 128 },
+	darkblue= { 0, 0, 139 },
+	mediumblue= { 0, 0, 205 },
+	blue= { 0, 0, 255 },
+	darkgreen= { 0, 100, 0 },
+	green= { 0, 128, 0 },
+	teal= { 0, 128, 128 },
+	darkcyan= { 0, 139, 139 },
+	deepskyblue= { 0, 191, 255 },
+	darkturquoise= { 0, 206, 209 },
+	mediumspringgreen= { 0, 250, 154 },
+	lime= { 0, 255, 0 },
+	springgreen= { 0, 255, 127 },
+	aqua= { 0, 255, 255 },
+	cyan= { 0, 255, 255 },
+	midnightblue= { 25, 25, 112 },
+	dodgerblue= { 30, 144, 255 },
+	forestgreen= { 34, 139, 34 },
+	seagreen= { 46, 139, 87 },
+	darkslategray= { 47, 79, 79 },
+	darkslategrey= { 47, 79, 79 },
+	limegreen= { 50, 205, 50 },
+	mediumseagreen= { 60, 179, 113 },
+	turquoise= { 64, 224, 208 },
+	royalblue= { 65, 105, 225 },
+	steelblue= { 70, 130, 180 },
+	darkslateblue= { 72, 61, 139 },
+	mediumturquoise= { 72, 209, 204 },
+	indigo= { 75, 0, 130 },
+	darkolivegreen= { 85, 107, 47 },
+	cadetblue= { 95, 158, 160 },
+	cornflowerblue= { 100, 149, 237 },
+	mediumaquamarine= { 102, 205, 170 },
+	dimgray= { 105, 105, 105 },
+	dimgrey= { 105, 105, 105 },
+	slateblue= { 106, 90, 205 },
+	olivedrab= { 107, 142, 35 },
+	slategray= { 112, 128, 144 },
+	slategrey= { 112, 128, 144 },
+	lightslategray= { 119, 136, 153 },
+	lightslategrey= { 119, 136, 153 },
+	mediumslateblue= { 123, 104, 238 },
+	lawngreen= { 124, 252, 0 },
+	chartreuse= { 127, 255, 0 },
+	aquamarine= { 127, 255, 212 },
+	maroon= { 128, 0, 0 },
+	purple= { 128, 0, 128 },
+	olive= { 128, 128, 0 },
+	gray= { 128, 128, 128 },
+	grey= { 128, 128, 128 },
+	skyblue= { 135, 206, 235 },
+	lightskyblue= { 135, 206, 250 },
+	blueviolet= { 138, 43, 226 },
+	darkred= { 139, 0, 0 },
+	darkmagenta= { 139, 0, 139 },
+	saddlebrown= { 139, 69, 19 },
+	darkseagreen= { 143, 188, 143 },
+	lightgreen= { 144, 238, 144 },
+	mediumpurple= { 147, 112, 216 },
+	darkviolet= { 148, 0, 211 },
+	palegreen= { 152, 251, 152 },
+	darkorchid= { 153, 50, 204 },
+	yellowgreen= { 154, 205, 50 },
+	sienna= { 160, 82, 45 },
+	brown= { 165, 42, 42 },
+	darkgray= { 169, 169, 169 },
+	darkgrey= { 169, 169, 169 },
+	lightblue= { 173, 216, 230 },
+	greenyellow= { 173, 255, 47 },
+	paleturquoise= { 175, 238, 238 },
+	lightsteelblue= { 176, 196, 222 },
+	powderblue= { 176, 224, 230 },
+	firebrick= { 178, 34, 34 },
+	darkgoldenrod= { 184, 134, 11 },
+	mediumorchid= { 186, 85, 211 },
+	rosybrown= { 188, 143, 143 },
+	darkkhaki= { 189, 183, 107 },
+	silver= { 192, 192, 192 },
+	mediumvioletred= { 199, 21, 133 },
+	indianred= { 205, 92, 92 },
+	peru= { 205, 133, 63 },
+	chocolate= { 210, 105, 30 },
+	tan= { 210, 180, 140 },
+	lightgray= { 211, 211, 211 },
+	lightgrey= { 211, 211, 211 },
+	palevioletred= { 216, 112, 147 },
+	thistle= { 216, 191, 216 },
+	orchid= { 218, 112, 214 },
+	goldenrod= { 218, 165, 32 },
+	crimson= { 220, 20, 60 },
+	gainsboro= { 220, 220, 220 },
+	plum= { 221, 160, 221 },
+	burlywood= { 222, 184, 135 },
+	lightcyan= { 224, 255, 255 },
+	lavender= { 230, 230, 250 },
+	darksalmon= { 233, 150, 122 },
+	violet= { 238, 130, 238 },
+	palegoldenrod= { 238, 232, 170 },
+	lightcoral= { 240, 128, 128 },
+	khaki= { 240, 230, 140 },
+	aliceblue= { 240, 248, 255 },
+	honeydew= { 240, 255, 240 },
+	azure= { 240, 255, 255 },
+	sandybrown= { 244, 164, 96 },
+	wheat= { 245, 222, 179 },
+	beige= { 245, 245, 220 },
+	whitesmoke= { 245, 245, 245 },
+	mintcream= { 245, 255, 250 },
+	ghostwhite= { 248, 248, 255 },
+	salmon= { 250, 128, 114 },
+	antiquewhite= { 250, 235, 215 },
+	linen= { 250, 240, 230 },
+	lightgoldenrodyellow= { 250, 250, 210 },
+	oldlace= { 253, 245, 230 },
+	red= { 255, 0, 0 },
+	fuchsia= { 255, 0, 255 },
+	magenta= { 255, 0, 255 },
+	deeppink= { 255, 20, 147 },
+	orangered= { 255, 69, 0 },
+	tomato= { 255, 99, 71 },
+	hotpink= { 255, 105, 180 },
+	coral= { 255, 127, 80 },
+	darkorange= { 255, 140, 0 },
+	lightsalmon= { 255, 160, 122 },
+	orange= { 255, 165, 0 },
+	lightpink= { 255, 182, 193 },
+	pink= { 255, 192, 203 },
+	gold= { 255, 215, 0 },
+	peachpuff= { 255, 218, 185 },
+	navajowhite= { 255, 222, 173 },
+	moccasin= { 255, 228, 181 },
+	bisque= { 255, 228, 196 },
+	mistyrose= { 255, 228, 225 },
+	blanchedalmond= { 255, 235, 205 },
+	papayawhip= { 255, 239, 213 },
+	lavenderblush= { 255, 240, 245 },
+	seashell= { 255, 245, 238 },
+	cornsilk= { 255, 248, 220 },
+	lemonchiffon= { 255, 250, 205 },
+	floralwhite= { 255, 250, 240 },
+	snow= { 255, 250, 250 },
+	yellow= { 255, 255, 0 },
+	lightyellow= { 255, 255, 224 },
+	ivory= { 255, 255, 240 },
+	white= { 255, 255, 255 }
+}
+
 return Color
 
---- Color cache
-    -- A table of predefined color tables
-    -- These keys can be passed to Color:fromString()
-    -- @field black {r=0,g=0,b=0,a=255}
-    -- @field navy {r=0,g=0,b=128,a=255}
-    -- @field darkblue {r=0,g=0,b=139,a=255}
-    -- @field mediumblue {r=0,g=0,b=205,a=255}
-    -- @field blue {r=0,g=0,b=255,a=255}
-    -- @field darkgreen {r=0,g=100,b=0,a=255}
-    -- @field green {r=0,g=128,b=0,a=255}
-    -- @field teal {r=0,g=128,b=128,a=255}
-    -- @field darkcyan {r=0,g=139,b=139,a=255}
-    -- @field deepskyblue {r=0,g=191,b=255,a=255}
-    -- @field darkturquoise {r=0,g=206,b=209,a=255}
-    -- @field mediumspringgreen {r=0,g=250,b=154,a=255}
-    -- @field lime {r=0,g=255,b=0,a=255}
-    -- @field springgreen {r=0,g=255,b=127,a=255}
-    -- @field aqua {r=0,g=255,b=255,a=255}
-    -- @field cyan {r=0,g=255,b=255,a=255}
-    -- @field midnightblue {r=25,g=25,b=112,a=255}
-    -- @field dodgerblue {r=30,g=144,b=255,a=255}
-    -- @field forestgreen {r=34,g=139,b=34,a=255}
-    -- @field seagreen {r=46,g=139,b=87,a=255}
-    -- @field darkslategray {r=47,g=79,b=79,a=255}
-    -- @field darkslategrey {r=47,g=79,b=79,a=255}
-    -- @field limegreen {r=50,g=205,b=50,a=255}
-    -- @field mediumseagreen {r=60,g=179,b=113,a=255}
-    -- @field turquoise {r=64,g=224,b=208,a=255}
-    -- @field royalblue {r=65,g=105,b=225,a=255}
-    -- @field steelblue {r=70,g=130,b=180,a=255}
-    -- @field darkslateblue {r=72,g=61,b=139,a=255}
-    -- @field mediumturquoise {r=72,g=209,b=204,a=255}
-    -- @field indigo {r=75,g=0,b=130,a=255}
-    -- @field darkolivegreen {r=85,g=107,b=47,a=255}
-    -- @field cadetblue {r=95,g=158,b=160,a=255}
-    -- @field cornflowerblue {r=100,g=149,b=237,a=255}
-    -- @field mediumaquamarine {r=102,g=205,b=170,a=255}
-    -- @field dimgray {r=105,g=105,b=105,a=255}
-    -- @field dimgrey {r=105,g=105,b=105,a=255}
-    -- @field slateblue {r=106,g=90,b=205,a=255}
-    -- @field olivedrab {r=107,g=142,b=35,a=255}
-    -- @field slategray {r=112,g=128,b=144,a=255}
-    -- @field slategrey {r=112,g=128,b=144,a=255}
-    -- @field lightslategray {r=119,g=136,b=153,a=255}
-    -- @field lightslategrey {r=119,g=136,b=153,a=255}
-    -- @field mediumslateblue {r=123,g=104,b=238,a=255}
-    -- @field lawngreen {r=124,g=252,b=0,a=255}
-    -- @field chartreuse {r=127,g=255,b=0,a=255}
-    -- @field aquamarine {r=127,g=255,b=212,a=255}
-    -- @field maroon {r=128,g=0,b=0,a=255}
-    -- @field purple {r=128,g=0,b=128,a=255}
-    -- @field olive {r=128,g=128,b=0,a=255}
-    -- @field gray {r=128,g=128,b=128,a=255}
-    -- @field grey {r=128,g=128,b=128,a=255}
-    -- @field skyblue {r=135,g=206,b=235,a=255}
-    -- @field lightskyblue {r=135,g=206,b=250,a=255}
-    -- @field blueviolet {r=138,g=43,b=226,a=255}
-    -- @field darkred {r=139,g=0,b=0,a=255}
-    -- @field darkmagenta {r=139,g=0,b=139,a=255}
-    -- @field saddlebrown {r=139,g=69,b=19,a=255}
-    -- @field darkseagreen {r=143,g=188,b=143,a=255}
-    -- @field lightgreen {r=144,g=238,b=144,a=255}
-    -- @field mediumpurple {r=147,g=112,b=216,a=255}
-    -- @field darkviolet {r=148,g=0,b=211,a=255}
-    -- @field palegreen {r=152,g=251,b=152,a=255}
-    -- @field darkorchid {r=153,g=50,b=204,a=255}
-    -- @field yellowgreen {r=154,g=205,b=50,a=255}
-    -- @field sienna {r=160,g=82,b=45,a=255}
-    -- @field brown {r=165,g=42,b=42,a=255}
-    -- @field darkgray {r=169,g=169,b=169,a=255}
-    -- @field darkgrey {r=169,g=169,b=169,a=255}
-    -- @field lightblue {r=173,g=216,b=230,a=255}
-    -- @field greenyellow {r=173,g=255,b=47,a=255}
-    -- @field paleturquoise {r=175,g=238,b=238,a=255}
-    -- @field lightsteelblue {r=176,g=196,b=222,a=255}
-    -- @field powderblue {r=176,g=224,b=230,a=255}
-    -- @field firebrick {r=178,g=34,b=34,a=255}
-    -- @field darkgoldenrod {r=184,g=134,b=11,a=255}
-    -- @field mediumorchid {r=186,g=85,b=211,a=255}
-    -- @field rosybrown {r=188,g=143,b=143,a=255}
-    -- @field darkkhaki {r=189,g=183,b=107,a=255}
-    -- @field silver {r=192,g=192,b=192,a=255}
-    -- @field mediumvioletred {r=199,g=21,b=133,a=255}
-    -- @field indianred {r=205,g=92,b=92,a=255}
-    -- @field peru {r=205,g=133,b=63,a=255}
-    -- @field chocolate {r=210,g=105,b=30,a=255}
-    -- @field tan {r=210,g=180,b=140,a=255}
-    -- @field lightgray {r=211,g=211,b=211,a=255}
-    -- @field lightgrey {r=211,g=211,b=211,a=255}
-    -- @field palevioletred {r=216,g=112,b=147,a=255}
-    -- @field thistle {r=216,g=191,b=216,a=255}
-    -- @field orchid {r=218,g=112,b=214,a=255}
-    -- @field goldenrod {r=218,g=165,b=32,a=255}
-    -- @field crimson {r=220,g=20,b=60,a=255}
-    -- @field gainsboro {r=220,g=220,b=220,a=255}
-    -- @field plum {r=221,g=160,b=221,a=255}
-    -- @field burlywood {r=222,g=184,b=135,a=255}
-    -- @field lightcyan {r=224,g=255,b=255,a=255}
-    -- @field lavender {r=230,g=230,b=250,a=255}
-    -- @field darksalmon {r=233,g=150,b=122,a=255}
-    -- @field violet {r=238,g=130,b=238,a=255}
-    -- @field palegoldenrod {r=238,g=232,b=170,a=255}
-    -- @field lightcoral {r=240,g=128,b=128,a=255}
-    -- @field khaki {r=240,g=230,b=140,a=255}
-    -- @field aliceblue {r=240,g=248,b=255,a=255}
-    -- @field honeydew {r=240,g=255,b=240,a=255}
-    -- @field azure {r=240,g=255,b=255,a=255}
-    -- @field sandybrown {r=244,g=164,b=96,a=255}
-    -- @field wheat {r=245,g=222,b=179,a=255}
-    -- @field beige {r=245,g=245,b=220,a=255}
-    -- @field whitesmoke {r=245,g=245,b=245,a=255}
-    -- @field mintcream {r=245,g=255,b=250,a=255}
-    -- @field ghostwhite {r=248,g=248,b=255,a=255}
-    -- @field salmon {r=250,g=128,b=114,a=255}
-    -- @field antiquewhite {r=250,g=235,b=215,a=255}
-    -- @field linen {r=250,g=240,b=230,a=255}
-    -- @field lightgoldenrodyellow {r=250,g=250,b=210,a=255}
-    -- @field oldlace {r=253,g=245,b=230,a=255}
-    -- @field red {r=255,g=0,b=0,a=255}
-    -- @field fuchsia {r=255,g=0,b=255,a=255}
-    -- @field magenta {r=255,g=0,b=255,a=255}
-    -- @field deeppink {r=255,g=20,b=147,a=255}
-    -- @field orangered {r=255,g=69,b=0,a=255}
-    -- @field tomato {r=255,g=99,b=71,a=255}
-    -- @field hotpink {r=255,g=105,b=180,a=255}
-    -- @field coral {r=255,g=127,b=80,a=255}
-    -- @field darkorange {r=255,g=140,b=0,a=255}
-    -- @field lightsalmon {r=255,g=160,b=122,a=255}
-    -- @field orange {r=255,g=165,b=0,a=255}
-    -- @field lightpink {r=255,g=182,b=193,a=255}
-    -- @field pink {r=255,g=192,b=203,a=255}
-    -- @field gold {r=255,g=215,b=0,a=255}
-    -- @field peachpuff {r=255,g=218,b=185,a=255}
-    -- @field navajowhite {r=255,g=222,b=173,a=255}
-    -- @field moccasin {r=255,g=228,b=181,a=255}
-    -- @field bisque {r=255,g=228,b=196,a=255}
-    -- @field mistyrose {r=255,g=228,b=225,a=255}
-    -- @field blanchedalmond {r=255,g=235,b=205,a=255}
-    -- @field papayawhip {r=255,g=239,b=213,a=255}
-    -- @field lavenderblush {r=255,g=240,b=245,a=255}
-    -- @field seashell {r=255,g=245,b=238,a=255}
-    -- @field cornsilk {r=255,g=248,b=220,a=255}
-    -- @field lemonchiffon {r=255,g=250,b=205,a=255}
-    -- @field floralwhite {r=255,g=250,b=240,a=255}
-    -- @field snow {r=255,g=250,b=250,a=255}
-    -- @field yellow {r=255,g=255,b=0,a=255}
-    -- @field lightyellow {r=255,g=255,b=224,a=255}
-    -- @field ivory {r=255,g=255,b=240,a=255}
-    -- @field white {r=255,g=255,b=255,a=255}
-    -- @table Color._cache

--- a/src/rot/display.lua
+++ b/src/rot/display.lua
@@ -39,13 +39,13 @@ function Display:init(w, h, scale, dfg, dbg, fullOrFlags, vsync, fsaa)
         self.drawQ=self.graphics.drawq
     end
 
-    self.defaultForegroundColor=dfg and dfg or {r=235,g=235,b=235,a=255}
-    self.defaultBackgroundColor=dbg and dbg or {r=15,g=15,b=15,a=255}
+    self.defaultForegroundColor=dfg and dfg or { 235, 235, 235, 255 }
+    self.defaultBackgroundColor=dbg and dbg or { 15, 15, 15, 255 }
 
-    self.graphics.setBackgroundColor(self.defaultBackgroundColor.r,
-                                     self.defaultBackgroundColor.g,
-                                     self.defaultBackgroundColor.b,
-                                     self.defaultBackgroundColor.a)
+    self.graphics.setBackgroundColor(self.defaultBackgroundColor[1],
+                                     self.defaultBackgroundColor[2],
+                                     self.defaultBackgroundColor[3],
+                                     self.defaultBackgroundColor[4])
 
     self.canvas=self.graphics.newCanvas(self.charWidth*self.widthInChars, self.charHeight*self.heightInChars)
 
@@ -253,13 +253,13 @@ end
 function Display:_validateForegroundColor(c)
 	c = c and c or self.defaultForegroundColor
     for k,_ in pairs(c) do c[k]=self:_clamp(c[k]) end
-	assert(c.a and c.r and c.g and c.b, 'Foreground Color must be of type { r = int, g = int, b = int, a = int }')
+	assert(#c > 2, 'Foreground Color must be of type { r, g, b, a }')
 	return c
 end
 function Display:_validateBackgroundColor(c)
 	c = c and c or self.defaultBackgroundColor
     for k,_ in pairs(c) do c[k]=self:_clamp(c[k]) end
-	assert(c.a and c.r and c.g and c.b, 'Background Color must be of type { r = int, g = int, b = int, a = int }')
+	assert(#c > 2, 'Background Color must be of type { r, g, b, a }')
 	return c
 end
 function Display:_validateHeight(y, h)
@@ -270,7 +270,7 @@ function Display:_validateHeight(y, h)
 end
 function Display:_setColor(c)
 	c = c and c or self.defaultForegroundColor
-	love.graphics.setColor(c.r, c.g, c.b, c.a)
+	love.graphics.setColor(c[1], c[2], c[3], c[4])
 end
 function Display:_clamp(n)
     return n<0 and 0 or n>255 and 255 or n

--- a/tests/expect.lua
+++ b/tests/expect.lua
@@ -1,0 +1,10 @@
+-- Some of Jasmine's API mapped onto Busted. Makes tests easier to port.
+return function (assert)
+    return function (a)
+        return {
+            toEqual = function (b) return assert.are.same(b, a) end,
+            toBe = function (b) return assert.are.equal(b, a) end,
+        }
+    end
+end
+

--- a/tests/spec/color.lua
+++ b/tests/spec/color.lua
@@ -1,0 +1,186 @@
+local ROT = require 'src.rot'
+local expect = require 'tests.expect' (assert)
+
+describe("Color", function()
+	describe("add", function()
+		it("should add two colors", function()
+			expect(ROT.Color:add({1,2,3}, {3,4,5})).toEqual({4,6,8})
+		end)
+		it("should add three colors", function()
+			expect(ROT.Color:add({1,2,3}, {3,4,5}, {100,200,300})).toEqual({104,206,308})
+		end)
+		it("should add one color (noop)", function()
+			expect(ROT.Color:add({1,2,3})).toEqual({1,2,3})
+		end)
+
+		it("should not modify first argument values", function()
+			local c1 = {1,2,3}
+			local c2 = {3,4,5}
+			ROT.Color:add(c1, c2)
+			expect(c1).toEqual({1,2,3})
+		end)
+	end)
+
+	describe("add_", function()
+		it("should add two colors", function()
+			expect(ROT.Color:add_({1,2,3}, {3,4,5})).toEqual({4,6,8})
+		end)
+		it("should add three colors", function()
+			expect(ROT.Color:add_({1,2,3}, {3,4,5}, {100,200,300})).toEqual({104,206,308})
+		end)
+		it("should add one color (noop)", function()
+			expect(ROT.Color:add_({1,2,3})).toEqual({1,2,3})
+		end)
+
+		it("should modify first argument values", function()
+			local c1 = {1,2,3}
+			local c2 = {3,4,5}
+			ROT.Color:add_(c1, c2)
+			expect(c1).toEqual({4,6,8})
+		end)
+		it("should return first argument", function()
+			local c1 = {1,2,3}
+			local c2 = {3,4,5}
+			local c3 = ROT.Color:add_(c1, c2)
+			expect(c1).toBe(c3)
+		end)
+	end)
+
+	describe("multiply", function()
+		it("should multiply two colors", function()
+			expect(ROT.Color:multiply({100,200,300}, {51,51,51})).toEqual({20,40,60})
+		end)
+		it("should multiply three colors", function()
+			expect(ROT.Color:multiply({100,200,300}, {51,51,51}, {510,510,510})).toEqual({40,80,120})
+		end)
+		it("should multiply one color (noop)", function()
+			expect(ROT.Color:multiply({1,2,3})).toEqual({1,2,3})
+		end)
+		it("should not modify first argument values", function()
+			local c1 = {1,2,3}
+			local c2 = {3,4,5}
+			ROT.Color:multiply(c1, c2)
+			expect(c1).toEqual({1,2,3})
+		end)
+		it("should round values", function()
+			expect(ROT.Color:multiply({100,200,300}, {10, 10, 10})).toEqual({4,8,12})
+		end)
+	end)
+
+	describe("multiply_", function()
+		it("should multiply two colors", function()
+			expect(ROT.Color:multiply_({100,200,300}, {51,51,51})).toEqual({20,40,60})
+		end)
+		it("should multiply three colors", function()
+			expect(ROT.Color:multiply_({100,200,300}, {51,51,51}, {510,510,510})).toEqual({40,80,120})
+		end)
+		it("should multiply one color (noop)", function()
+			expect(ROT.Color:multiply_({1,2,3})).toEqual({1,2,3})
+		end)
+		it("should modify first argument values", function()
+			local c1 = {100,200,300}
+			local c2 = {51,51,51}
+			ROT.Color:multiply_(c1, c2)
+			expect(c1).toEqual({20,40,60})
+		end)
+		it("should round values", function()
+			expect(ROT.Color:multiply_({100,200,300}, {10, 10, 10})).toEqual({4,8,12})
+		end)
+		it("should return first argument", function()
+			local c1 = {1,2,3}
+			local c2 = {3,4,5}
+			local c3 = ROT.Color:multiply_(c1, c2)
+			expect(c1).toBe(c3)
+		end)
+	end)
+
+	describe("fromString", function()
+		it("should handle rgb() colors", function()
+			expect(ROT.Color:fromString("rgb(10, 20, 33)")).toEqual({10, 20, 33})
+		end)
+		it("should handle #abcdef colors", function()
+			expect(ROT.Color:fromString("#1a2f3c")).toEqual({26, 47, 60})
+		end)
+		it("should handle #abc colors", function()
+			expect(ROT.Color:fromString("#ca8")).toEqual({204, 170, 136})
+		end)
+		it("should handle named colors", function()
+			expect(ROT.Color:fromString("red")).toEqual({255, 0, 0})
+		end)
+		it("should not handle nonexistant colors", function()
+			expect(ROT.Color:fromString("lol")).toEqual({0, 0, 0})
+		end)
+	end)
+
+	describe("toRGB", function()
+		it("should serialize to rgb", function()
+			expect(ROT.Color:toRGB({10, 20, 30})).toEqual("rgb(10,20,30)")
+		end)
+		it("should clamp values to 0..255", function()
+			expect(ROT.Color:toRGB({-100, 20, 2000})).toEqual("rgb(0,20,255)")
+		end)
+	end)
+
+	describe("toHex", function()
+		it("should serialize to hex", function()
+			expect(ROT.Color:toHex({10, 20, 40})).toEqual("#0a1428")
+		end)
+		it("should clamp values to 0..255", function()
+			expect(ROT.Color:toHex({-100, 20, 2000})).toEqual("#0014ff")
+		end)
+	end)
+
+	describe("interpolate", function()
+		it("should intepolate two colors", function()
+			expect(ROT.Color:interpolate({10, 20, 40}, {100, 200, 300}, 0.1)).toEqual({19, 38, 66})
+		end)
+		it("should round values", function()
+			expect(ROT.Color:interpolate({10, 20, 40}, {15, 30, 53}, 0.5)).toEqual({13, 25, 47})
+		end)
+		it("should default to 0.5 factor", function()
+			expect(ROT.Color:interpolate({10, 20, 40}, {20, 30, 40})).toEqual({15, 25, 40})
+		end)
+	end)
+
+	describe("interpolateHSL", function()
+		it("should intepolate two colors", function()
+			expect(ROT.Color:interpolateHSL({10, 20, 40}, {100, 200, 300}, 0.1)).toEqual({12, 33, 73})
+		end)
+	end)
+
+	describe("randomize", function()
+		it("should maintain constant diff when a number is used", function()
+			local c = ROT.Color:randomize({100, 100, 100}, 100)
+			expect(c[1]).toBe(c[2])
+			expect(c[2]).toBe(c[3])
+		end)
+	end)
+
+	describe("rgb2hsl and hsl2rgb", function()
+		it("should correctly convert to HSL and back", function()
+			local rgb = {
+				{255, 255, 255},
+				{0, 0, 0},
+				{255, 0, 0},
+				{30, 30, 30},
+				{100, 120, 140}
+			}
+
+			while (rgb.length) do
+				local color = rgb.pop()
+				local hsl = ROT.Color:rgb2hsl(color)
+				local rgb2 = ROT.Color:hsl2rgb(hsl)
+				expect(rgb2).toEqual(color)
+			end
+		end)
+
+		it("should round converted values", function()
+			local hsl = {0.5, 0, 0.3}
+			local rgb = ROT.Color:hsl2rgb(hsl)
+			for i=1, #rgb do
+				expect(math.floor(rgb[i] + 0.5)).toEqual(rgb[i])
+			end
+		end)
+	end)
+end)
+


### PR DESCRIPTION
This change switches from string-indexed colors for numeric-indexed.

```lua
{ r = 0, g = 0, b = 0 }
-- becomes
{ 0, 0, 0 }
```

ROT.Color is now used statically, as in rot.js, instead of needing to be instantiated (it can still be instantiated, but there's no reason to do that). Fixed some functions that were variadic in rot.js to also be variadic here, instead of taking a table-of-tables as a second argument. 

Also converted the relevant Jasmine tests for Busted, and fixed things up so all tests pass. This was the main motivation for the change; I wanted to use something as close as possible to the existing tests. This change should also improve performance in some parts (no more `pairs`, shared cache) and makes colors slightly more convenient to define.

Kept colon instead of dot notation for symmetry with ROT.RNG, but could be changed to dot notation to reinforce the idea that it's static. That would also make it suitable as a prototype for color objects, since almost every function takes a color as its first parameter. Might be something to consider, anyway.