### PR TITLE
Fix RNG reseeding bug

### DIFF
--- a/src/rot/rng.lua
+++ b/src/rot/rng.lua
@@ -50,6 +50,7 @@ end
 -- seed the rng
 -- @tparam[opt=os.clock()] number s A number to base the rng from
 function RNG:setSeed(seed)
+    self.c = 1
     self.seed = seed or os.time()
 
     local mash = Mash()


### PR DESCRIPTION
Small bug fix, missed setting some initial state when seeding RNG. Caught this by running tests ported from rot.js. Tests were added in another branch and are not included in this commit; will add them when #32 is merged or rejected.