### PR TITLE
make digger deterministic (fix #46)

### DIFF
--- a/examples/digger.lua
+++ b/examples/digger.lua
@@ -13,10 +13,13 @@ function love.update()
     if update then
         update=false
         dgr:create(calbak)
-        local rooms=dgr:getDoors()
-        for k,v in pairs(rooms) do
+        local doors=dgr:getDoors()
+        for k,v in pairs(doors) do
             f:write('+', v.x, v.y)
         end
     end
 end
-function love.keypressed(key) update=true end
+function love.keypressed(key)
+    ROT.RNG:setSeed(key)
+    update=true
+end

--- a/src/rot/map/dungeon.lua
+++ b/src/rot/map/dungeon.lua
@@ -37,4 +37,35 @@ end
 -- @treturn table A table containing objects of the type ROT.Map.Corridor
 function Dungeon:getCorridors() return self._corridors end
 
+function Dungeon:_getDetail(name, x, y)
+    local t = self[name]
+    for i = 1, #t do
+        if t[i].x == x and t[i].y == y then return t, i end
+    end
+end
+
+function Dungeon:_setDetail(name, x, y, value)
+    local detail, i = self:_getDetail(name, x, y)
+    if detail then
+        if value then
+            detail.value = value
+        else
+            table.remove(self[name], i)
+        end
+    elseif value then
+        local t = self[name]
+        detail = { x = x, y = y, value = value }
+        t[#t + 1] = detail
+    end
+    return detail
+end
+
+function Dungeon:getWall(x, y)
+    return self:_getDetail('_walls', x, y)
+end
+
+function Dungeon:setWall(x, y, value)
+    return self:_setDetail('_walls', x, y, value)
+end
+
 return Dungeon


### PR DESCRIPTION
Fix Digger's use of pairs causing indeterminate results.

Added some stuff to Dungeon so this can be used for other map generators if we feel like it (just to get rid of string concatenation / pairs; doesn't look like there are any other problems with determinism right now).

Digger example uses key pressed as seed, so you can keep hitting the same key and verify the dungeon is always the same.
