### PR TITLE
add underscore in textDisplay:drawText()

### DIFF
--- a/src/rot/textDisplay.lua
+++ b/src/rot/textDisplay.lua
@@ -265,7 +265,7 @@ function TextDisplay:drawText(x, y, text, maxWidth)
     local cx = x
     local cy = y
     local lines = 1
-    if not maxWidth then maxWidth = self.widthInChars-x end
+    if not maxWidth then maxWidth = self._widthInChars-x end
 
     local tokens = ROT.Text.tokenize(text, maxWidth)
 


### PR DESCRIPTION
There was a missing underscore for widthInChars in the textDisplay module.